### PR TITLE
Refactor: Use poll functions internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ instant = "0.1"
 getrandom = "0.1"
 
 [dev-dependencies]
-async-std = "1.5"
+async-std = { version = "1.5.0", features = ["attributes"] }
 env_logger = "0.7.1"
 hypercore = { git = "https://github.com/datrs/hypercore", branch = "master" }
 random-access-disk = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypercore-protocol"
-version = "0.0.2"
+version = "0.1.0"
 license = "MIT OR Apache-2.0"
 description = "Replication protocol for Hypercore feeds"
 authors = ["Franz Heinzmann (Frando) <frando@unbiskant.org>"]
@@ -22,7 +22,8 @@ categories = [
 bench = false
 
 [dependencies]
-futures = "0.3"
+async-channel = "1.5"
+futures = "0.3.12"
 snow = { version = "0.7.0-alpha5", features = ["risky-raw-split"] }
 prost = "0.6"
 bytes = "0.5"
@@ -39,7 +40,7 @@ instant = "0.1"
 getrandom = "0.1"
 
 [dev-dependencies]
-async-std = { version = "1.5.0", features = ["attributes"] }
+async-std = { version = "1.9.0", features = ["attributes", "unstable"] }
 env_logger = "0.7.1"
 hypercore = { git = "https://github.com/datrs/hypercore", branch = "master" }
 random-access-disk = "2.0.0"
@@ -48,8 +49,8 @@ random-access-storage = "4.0.0"
 anyhow = "1.0.28"
 criterion = "0.3.2"
 pretty-bytes = "0.2.2"
-piper = "0.1.1"
 duplexify = "1.1.0"
+sluice = "0.5.4"
 
 [build-dependencies]
 prost-build = "0.6.1"
@@ -62,10 +63,10 @@ wasm-bindgen = [
 ]
 
 [profile.bench]
-debug = true
+# debug = true
 
 [profile.release]
-debug = true
+# debug = true
 
 [[bench]]
 name = "throughput"

--- a/examples/hypercore.rs
+++ b/examples/hypercore.rs
@@ -70,9 +70,7 @@ async fn onconnection<T: 'static>(
 where
     T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send,
 {
-    let mut protocol = ProtocolBuilder::new(is_initiator)
-        .connect(stream)
-        .into_stream();
+    let mut protocol = ProtocolBuilder::new(is_initiator).connect(stream);
 
     while let Some(event) = protocol.next().await {
         let event = event?;
@@ -96,6 +94,7 @@ where
                 }
             }
             Event::Close(_dkey) => {}
+            _ => {}
         }
     }
     Ok(())

--- a/examples/hypercore.rs
+++ b/examples/hypercore.rs
@@ -101,6 +101,7 @@ where
 }
 
 /// A container for hypercores.
+#[derive(Debug)]
 struct FeedStore<T>
 where
     T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send,
@@ -161,6 +162,11 @@ where
         let mut state = PeerState::default();
         let mut feed = self.feed.clone();
         task::spawn(async move {
+            let msg = Want {
+                start: 0,
+                length: None,
+            };
+            channel.send(Message::Want(msg)).await.unwrap();
             while let Some(message) = channel.next().await {
                 let result = onmessage(&mut feed, &mut state, &mut channel, message).await;
                 if let Err(e) = result {
@@ -222,11 +228,11 @@ where
             let value: Option<&[u8]> = match msg.value.as_ref() {
                 None => None,
                 Some(value) => {
-                    eprintln!(
-                        "recv idx {}: {:?}",
-                        msg.index,
-                        String::from_utf8(value.clone()).unwrap()
-                    );
+                    // eprintln!(
+                    //     "recv idx {}: {:?}",
+                    //     msg.index,
+                    //     String::from_utf8(value.clone()).unwrap()
+                    // );
                     Some(value)
                 }
             };

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,80 @@
+use crate::Protocol;
+use futures::io::{AsyncRead, AsyncWrite};
+
+/// Options for a Protocol instance.
+#[derive(Debug)]
+pub struct Options {
+    pub is_initiator: bool,
+    pub noise: bool,
+    pub encrypted: bool,
+}
+
+/// Build a Protocol instance with options.
+pub struct Builder(Options);
+
+impl Builder {
+    // Create a protocol builder.
+    pub fn new(is_initiator: bool) -> Self {
+        Self(Options {
+            is_initiator,
+            noise: true,
+            encrypted: true,
+        })
+    }
+
+    /// Default options for an initiating endpoint.
+    pub fn initiator() -> Self {
+        Self::new(true)
+    }
+
+    /// Default options for a responding endpoint.
+    pub fn responder() -> Self {
+        Self::new(false)
+    }
+
+    /// Set encrypted option.
+    pub fn set_encrypted(mut self, encrypted: bool) -> Self {
+        self.0.encrypted = encrypted;
+        self
+    }
+
+    /// Set handshake option.
+    pub fn set_noise(mut self, noise: bool) -> Self {
+        self.0.noise = noise;
+        self
+    }
+
+    /// Create the protocol from a stream that implements AsyncRead + AsyncWrite + Clone.
+    pub fn connect<S>(self, stream: S) -> Protocol<S, S>
+    where
+        S: AsyncRead + AsyncWrite + Send + Unpin + Clone + 'static,
+    {
+        Protocol::new(stream.clone(), stream, self.0)
+    }
+
+    /// Create the protocol from an AsyncRead reader and AsyncWrite writer.
+    pub fn connect_rw<R, W>(self, reader: R, writer: W) -> Protocol<R, W>
+    where
+        R: AsyncRead + Send + Unpin + 'static,
+        W: AsyncWrite + Send + Unpin + 'static,
+    {
+        Protocol::new(reader, writer, self.0)
+    }
+
+    #[deprecated(since = "0.0.1", note = "Use connect_rw")]
+    pub fn build_from_io<R, W>(self, reader: R, writer: W) -> Protocol<R, W>
+    where
+        R: AsyncRead + Send + Unpin + 'static,
+        W: AsyncWrite + Send + Unpin + 'static,
+    {
+        self.connect_rw(reader, writer)
+    }
+
+    #[deprecated(since = "0.0.1", note = "Use connect")]
+    pub fn build_from_stream<S>(self, stream: S) -> Protocol<S, S>
+    where
+        S: AsyncRead + AsyncWrite + Send + Unpin + Clone + 'static,
+    {
+        self.connect(stream)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@
 // Otherwise some macro calls in the next_loop are prohibited.
 #![recursion_limit = "256"]
 
+mod builder;
 mod channels;
 mod constants;
 mod message;
@@ -74,7 +75,8 @@ pub mod schema {
     pub use crate::message::ExtensionMessage;
 }
 
+pub use builder::{Builder as ProtocolBuilder, Options};
 pub use channels::Channel;
 pub use message::Message;
-pub use protocol::{Event, Protocol, ProtocolBuilder, ProtocolOptions, ProtocolStream};
+pub use protocol::{Event, Protocol, ProtocolStream};
 pub use util::discovery_key;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,8 @@
 //! Speak hypercore-protocol.
 //!
 //! Most basic example:
-//! ```should_panic
+//! ```no_run
 //! # async_std::task::block_on(async {
-//! # async_std::task::spawn(async move {
-//! #    futures_timer::Delay::new(std::time::Duration::from_secs(1)).await;
-//! #    panic!("exit")
-//! # });
 //! #
 //! use hypercore_protocol::{ProtocolBuilder, Event, Message};
 //! use hypercore_protocol::schema::*;
@@ -32,7 +28,7 @@
 //!     let key = vec![0u8; 32];
 //!     let mut protocol = ProtocolBuilder::new(is_initiator).connect(stream);
 //!
-//!     while let Ok(event) = protocol.loop_next().await {
+//!     while let Some(Ok(event)) = protocol.next().await {
 //!         eprintln!("[{}] received event {:?}", is_initiator, event);
 //!         match event {
 //!             Event::Handshake(_remote_key) => {
@@ -78,5 +74,5 @@ pub mod schema {
 pub use builder::{Builder as ProtocolBuilder, Options};
 pub use channels::Channel;
 pub use message::Message;
-pub use protocol::{Event, Protocol, ProtocolStream};
+pub use protocol::{DiscoveryKey, Event, Key, Protocol};
 pub use util::discovery_key;

--- a/src/noise/handshake.rs
+++ b/src/noise/handshake.rs
@@ -2,7 +2,6 @@
 use blake2_rfc::blake2b::Blake2b;
 use prost::Message;
 use rand::Rng;
-use snow;
 pub use snow::Keypair;
 use snow::{Builder, Error as SnowError, HandshakeState};
 use std::io::{Error, ErrorKind, Result};
@@ -145,7 +144,14 @@ impl Handshake {
             return Err(Error::new(ErrorKind::Other, "Handshake read after finish"));
         }
 
+        // eprintln!(
+        //     "[{}] HANDSHAKE recv len {} {:?}",
+        //     self.is_initiator(),
+        //     msg.len(),
+        //     msg
+        // );
         let rx_len = self.recv(&msg)?;
+        // eprintln!("[{}] HANDSHAKE recv post", self.is_initiator());
 
         if !self.is_initiator() && !self.did_receive {
             self.did_receive = true;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,10 +1,7 @@
-use futures::channel::mpsc::{Receiver, Sender};
-use futures::future::FutureExt;
+use async_channel::{Receiver, Sender};
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::io::{BufReader, BufWriter};
-use futures::ready;
-use futures::sink::SinkExt;
-use futures::stream::{SelectAll, Stream};
+use futures::stream::Stream;
 use futures::task::{Context, Poll};
 use futures_timer::Delay;
 use log::*;
@@ -16,7 +13,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use crate::builder::{Builder, Options};
-use crate::channels::{Channel, Channelizer};
+use crate::channels::{Channel, ChannelMap};
 use crate::constants::DEFAULT_KEEPALIVE;
 use crate::message::{ChannelMessage, Message};
 use crate::noise::{Handshake, HandshakeResult};
@@ -26,45 +23,35 @@ use crate::util::map_channel_err;
 use crate::util::pretty_hash;
 use crate::writer::ProtocolWriter;
 
+macro_rules! return_error {
+    ($msg:expr) => {
+        if let Err(e) = $msg {
+            return Poll::Ready(Err(e));
+        }
+    };
+}
+
 const CHANNEL_CAP: usize = 1000;
 const KEEPALIVE_DURATION: Duration = Duration::from_secs(DEFAULT_KEEPALIVE as u64);
 
 pub type RemotePublicKey = Vec<u8>;
 pub type DiscoveryKey = Vec<u8>;
 pub type Key = Vec<u8>;
-pub type ChannelId = usize;
 
 /// A protocol event.
 pub enum Event {
     Handshake(RemotePublicKey),
     DiscoveryKey(DiscoveryKey),
-    Open(ChannelId, DiscoveryKey),
-    Message(ChannelId, Message),
-    Close(ChannelId),
+    Channel(Channel),
+    Close(DiscoveryKey),
     Error(std::io::Error),
 }
 
-pub enum Action {
+/// A protocol command.
+pub enum Command {
     Open(Key),
     Close(DiscoveryKey),
-    Send(ChannelId, Message),
 }
-
-// struct Channelizzer<R, W>
-// where
-//     R: AsyncRead + Send + Unpin + 'static,
-//     W: AsyncWrite + Send + Unpin + 'static,
-// {
-//     protocol: Protocol<R, W>,
-// }
-// impl Stream for Channelizer {
-//     type Item = C
-//     fn poll_next(
-//         mut self: Pin<&mut Self>,
-//         cx: &mut std::task::Context<'_>,
-//     ) -> Poll<Option<Self::Item>> {
-//     }
-// }
 
 impl fmt::Debug for Event {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -75,11 +62,10 @@ impl fmt::Debug for Event {
             Event::DiscoveryKey(discovery_key) => {
                 write!(f, "DiscoveryKey({})", &pretty_hash(discovery_key))
             }
-            Event::Close(channel) => write!(f, "Close({})", channel),
-            Event::Open(channel, discovery_key) => {
-                write!(f, "Open({}, {})", channel, &pretty_hash(discovery_key))
+            Event::Channel(channel) => {
+                write!(f, "Channel({})", &pretty_hash(&channel.discovery_key))
             }
-            Event::Message(channel, message) => write!(f, "{:?} {:?}", channel, message),
+            Event::Close(discovery_key) => write!(f, "Close({})", &pretty_hash(discovery_key)),
             Event::Error(error) => write!(f, "{:?}", error),
         }
     }
@@ -105,9 +91,6 @@ impl fmt::Debug for State {
     }
 }
 
-/// The output of the set of channel senders.
-type OutboundMessagesReceiver = SelectAll<Box<dyn Stream<Item = ChannelMessage> + Send + Unpin>>;
-
 /// A Protocol stream.
 pub struct Protocol<R, W>
 where
@@ -119,17 +102,12 @@ where
     state: State,
     options: Options,
     handshake: Option<HandshakeResult>,
-    channels: Channelizer,
+    channels: ChannelMap,
     error: Option<Error>,
-    outbound_rx: OutboundMessagesReceiver,
-    control_rx: Receiver<ControlEvent>,
-    control_tx: ControlTx,
-    // outgoing: VecDeque<Event>,
+    command_rx: Receiver<Command>,
+    command_tx: CommandTx,
     keepalive: Delay,
-
-    // new fields
     queued_events: VecDeque<Event>,
-    queued_messages: VecDeque<Vec<u8>>,
 }
 
 impl<R, W> Protocol<R, W>
@@ -141,24 +119,19 @@ where
     pub fn new(reader: R, writer: W, options: Options) -> Self {
         let reader = ProtocolReader::new(BufReader::new(reader));
         let writer = ProtocolWriter::new(BufWriter::new(writer));
-        let (control_tx, control_rx) = futures::channel::mpsc::channel(CHANNEL_CAP);
+        let (command_tx, command_rx) = async_channel::bounded(CHANNEL_CAP);
         Protocol {
             writer,
             reader,
             options,
             state: State::NotInitialized,
-            channels: Channelizer::new(),
+            channels: ChannelMap::new(),
             handshake: None,
             error: None,
-            outbound_rx: SelectAll::new(),
-            control_rx,
-            control_tx: ControlTx(control_tx),
-            // outgoing: VecDeque::new(),
+            command_rx,
+            command_tx: CommandTx(command_tx),
             keepalive: Delay::new(Duration::from_secs(DEFAULT_KEEPALIVE as u64)),
-            // new fields
-            //
             queued_events: VecDeque::new(),
-            queued_messages: VecDeque::new(),
         }
     }
 
@@ -167,213 +140,24 @@ where
         Builder::new(is_initiator)
     }
 
-    fn init(&mut self) -> Result<()> {
-        trace!(
-            "protocol init, state {:?}, options {:?}",
-            self.state,
-            self.options
-        );
-        match self.state {
-            State::NotInitialized => {}
-            _ => return Ok(()),
-        };
-
-        self.state = if self.options.noise {
-            let mut handshake = Handshake::new(self.options.is_initiator)?;
-            // If the handshake start returns a buffer, send it now.
-            if let Some(buf) = handshake.start()? {
-                self.queue_message(buf.to_vec());
-            }
-            State::Handshake(Some(handshake))
-        } else {
-            State::Established
-        };
-
-        // self.reset_keepalive();
-
-        Ok(())
-    }
-
-    // fn reset_keepalive(&mut self) {
-    //     let keepalive_duration = Duration::from_secs(DEFAULT_KEEPALIVE as u64);
-    //     self.keepalive = Some(Delay::new(keepalive_duration).fuse());
-    // }
-
     pub fn is_initiator(&self) -> bool {
         self.options.is_initiator
     }
 
-    pub fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<Event>> {
-        let this = self.get_mut();
-
-        if let State::NotInitialized = this.state {
-            match this.init() {
-                Ok(_) => {}
-                Err(e) => return Poll::Ready(Err(e)),
-            }
-        }
-
-        loop {
-            // Drain queued events first.
-            if let Some(event) = this.queued_events.pop_front() {
-                return Poll::Ready(Ok(event));
-            }
-
-            // Send queued messages out.
-            while !this.queued_messages.is_empty() {
-                let res = ready!(Pin::new(&mut this.writer)
-                    .poll_write_message(this.queued_messages.front().unwrap(), cx));
-                this.writer.reset();
-                this.queued_messages.pop_front();
-                if let Err(e) = res {
-                    this.queued_events.push_back(Event::Error(e));
-                    continue;
-                }
-            }
-
-            // Check for outgoing messages.
-            match Pin::new(&mut this.outbound_rx).poll_next(cx) {
-                Poll::Pending => {}
-                // TODO: Can this actually happen?
-                Poll::Ready(None) => {}
-                Poll::Ready(Some(channel_message)) => {
-                    // If message is close, close the local channel.
-                    match channel_message {
-                        ChannelMessage {
-                            channel,
-                            message: Message::Close(_),
-                        } => {
-                            this.close_local(channel);
-                        }
-                        _ => {}
-                    };
-                    let res = this.queue_channel_message(channel_message);
-                    match res {
-                        Err(e) => return Poll::Ready(Err(e)),
-                        _ => {}
-                    }
-                }
-            }
-
-            // Poll the keepalive timer.
-            match Future::poll(Pin::new(&mut this.keepalive), cx) {
-                Poll::Pending => {}
-                Poll::Ready(_) => {
-                    this.queue_ping();
-                    this.keepalive.reset(KEEPALIVE_DURATION);
-                }
-            }
-
-            // Wait for incoming messages.
-            while let Poll::Ready(Some(message)) = Stream::poll_next(Pin::new(&mut this.reader), cx)
-            {
-                let res = match message {
-                    Ok(message) => this.on_message(message),
-                    Err(e) => Err(e),
-                };
-                if let Err(e) = res {
-                    this.queued_events.push_back(Event::Error(e));
-                    continue;
-                }
-            }
-
-            // Check if any events are enqueued.
-            if this.queued_events.is_empty() {
-                return Poll::Pending;
-            }
-        }
-    }
-
-    pub async fn loop_next(mut self: &mut Self) -> Result<Event> {
-        let fut = futures::future::poll_fn(move |cx| Protocol::poll_next(Pin::new(&mut self), cx));
-        fut.await
-    }
-
-    /// Wait for the next protocol event.
-    ///
-    /// This function should be called in a loop until this returns an error.
-    // pub async fn loop_next(&mut self) -> Result<Event> {
-    //     // trace!(
-    //     //     "[{}] loop_next start, state {:?} events.len {}",
-    //     //     self.is_initiator(),
-    //     //     self.state,
-    //     //     self.events.len()
-    //     // );
-    //     if let State::NotInitialized = self.state {
-    //         self.init().await?;
-    //     }
-
-    //     let mut keepalive = if let Some(keepalive) = self.keepalive.take() {
-    //         keepalive
-    //     } else {
-    //         Delay::new(KEEPALIVE_DURATION).fuse()
-    //     };
-
-    //     // Wait for new bytes to arrive, or for the keepalive to occur to send a ping.
-    //     // If data was received, reset the keepalive timer.
-    //     loop {
-    //         // trace!("[{}] loop_next loop in", self.is_initiator());
-
-    //         if let Some(event) = self.events.pop_front() {
-    //             return Ok(event);
-    //         }
-
-    //         let event = futures::select! {
-    //             // Keepalive timer for pings
-    //             _ = keepalive => {
-    //                 // trace!("[{}] loop_next ! keepalive", self.is_initiator());
-    //                 self.ping().await?;
-    //                 // TODO: It would be better to `reset` the keepalive and not recreate it.
-    //                 // I couldn't get this to work with `fuse()` though which is needed for
-    //                 // the `select!` macro.
-    //                 keepalive = Delay::new(KEEPALIVE_DURATION).fuse();
-    //                 None
-    //             },
-    //             // New wire message incoming
-    //             buf = self.reader.select_next_some() => {
-    //                 // trace!("[{}] loop_next ! incoming message", self.is_initiator());
-    //                 self.on_message(buf?).await?
-    //             },
-    //             // New outbound message
-    //             channel_message = self.outbound_rx.select_next_some() => {
-    //                 // trace!("[{}] loop_next ! outbound_rx", self.is_initiator());
-    //                 let event = match channel_message {
-    //                     ChannelMessage { channel, message: Message::Close(_) } => {
-    //                         self.close_local(channel).await?
-    //                     },
-    //                     _ => None
-    //                 };
-    //                 self.send(channel_message).await?;
-    //                 // trace!("[{}] loop_next ! outbound_rx SENT", self.is_initiator());
-    //                 event
-    //             },
-    //             // New control message
-    //             ev = self.control_rx.select_next_some() => {
-    //                 // trace!("[{}] loop_next ! control_rx", self.is_initiator());
-    //                 match ev {
-    //                     ControlEvent::Open(key) => {
-    //                         self.open(key).await?;
-    //                         None
-    //                     }
-    //                 }
-    //             },
-    //         };
-    //         // trace!(
-    //         //     "[{}] loop_next loop out, event {:?}",
-    //         //     self.is_initiator(),
-    //         //     event
-    //         // );
-    //         if let Some(event) = event {
-    //             self.keepalive = Some(keepalive);
-    //             return Ok(event);
-    //         }
-    //     }
-    // }
-
-    /// Get the peer's Noise public key.
+    /// Get your own Noise public key.
     ///
     /// Empty before the handshake completed.
-    pub fn remote_key(&self) -> Option<&[u8]> {
+    pub fn public_key(&self) -> Option<&[u8]> {
+        match &self.handshake {
+            None => None,
+            Some(handshake) => Some(handshake.local_pubkey.as_slice()),
+        }
+    }
+
+    /// Get the remote's Noise public key.
+    ///
+    /// Empty before the handshake completed.
+    pub fn remote_public_key(&self) -> Option<&[u8]> {
         match &self.handshake {
             None => None,
             Some(handshake) => Some(handshake.remote_pubkey.as_slice()),
@@ -385,27 +169,174 @@ where
         self.error = Some(error)
     }
 
-    fn on_message(&mut self, buf: Vec<u8>) -> Result<()> {
-        // trace!("onmessage, state {:?} msg len {}", self.state, buf.len());
+    /// Get a sender to send commands.
+    pub fn commands(&self) -> CommandTx {
+        self.command_tx.clone()
+    }
+
+    /// Give a command to the protocol.
+    pub async fn command(&mut self, command: Command) -> Result<()> {
+        self.command_tx.send(command).await
+    }
+
+    /// Open a new protocol channel.
+    ///
+    /// Once the other side proofed that it also knows the `key`, the channel is emitted as
+    /// `Event::Channel` on the protocol event stream.
+    pub async fn open(&mut self, key: Vec<u8>) -> Result<()> {
+        self.command_tx.open(key).await
+    }
+
+    /// Stop the protocol and return the inner reader and writer.
+    pub fn release(self) -> (R, W) {
+        (
+            self.reader.into_inner().into_inner(),
+            self.writer.into_inner().into_inner(),
+        )
+    }
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<Event>> {
+        let this = self.get_mut();
+
+        if let State::NotInitialized = this.state {
+            return_error!(this.init());
+        }
+
+        // Drain queued events first.
+        if let Some(event) = this.queued_events.pop_front() {
+            return Poll::Ready(Ok(event));
+        }
+
+        // Read and process incoming messages.
+        return_error!(this.poll_inbound_read(cx));
+
+        if let State::Established = this.state {
+            // Check for commands, but only once the connection is established.
+            return_error!(this.poll_commands(cx));
+            // Process and forward outgoing messages from the channels.
+            return_error!(this.poll_outbound_forward(cx));
+        }
+
+        // Poll the keepalive timer.
+        this.poll_keepalive(cx);
+
+        // Write queued outgoing messages to network.
+        return_error!(this.poll_outbound_write(cx));
+
+        // Check if any events are enqueued.
+        if let Some(event) = this.queued_events.pop_front() {
+            Poll::Ready(Ok(event))
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn init(&mut self) -> Result<()> {
+        debug!(
+            "protocol init, state {:?}, options {:?}",
+            self.state, self.options
+        );
         match self.state {
-            State::Handshake(_) => self.on_handshake_message(buf)?,
-            State::Established => self.on_proto_message(buf)?,
-            State::NotInitialized => panic!("cannot receive messages before starting the protocol"),
+            State::NotInitialized => {}
+            _ => return Ok(()),
         };
+
+        self.state = if self.options.noise {
+            let mut handshake = Handshake::new(self.options.is_initiator)?;
+            // If the handshake start returns a buffer, send it now.
+            if let Some(buf) = handshake.start()? {
+                self.queue_outbound_message(buf.to_vec());
+            }
+            State::Handshake(Some(handshake))
+        } else {
+            State::Established
+        };
+
         Ok(())
+    }
+
+    /// Poll commands.
+    fn poll_commands(self: &mut Self, cx: &mut Context) -> Result<()> {
+        while let Poll::Ready(Some(command)) = Pin::new(&mut self.command_rx).poll_next(cx) {
+            self.on_command(command)?;
+        }
+        Ok(())
+    }
+
+    /// Poll the keepalive timer and queue a ping message if needed.
+    fn poll_keepalive(self: &mut Self, cx: &mut Context) {
+        if let Poll::Ready(_) = Future::poll(Pin::new(&mut self.keepalive), cx) {
+            self.queue_ping();
+            self.keepalive.reset(KEEPALIVE_DURATION);
+        }
+    }
+
+    /// Poll the channels for outbound messages.
+    fn poll_outbound_forward(self: &mut Self, cx: &mut Context) -> Result<()> {
+        while let Poll::Ready(Some(channel_message)) =
+            Pin::new(&mut self.channels).poll_next_outbound(cx)
+        {
+            // If message is close, close the local channel.
+            if let ChannelMessage {
+                channel,
+                message: Message::Close(_),
+            } = channel_message
+            {
+                self.close_local(channel);
+            }
+            self.queue_outbound_channel_message(channel_message)?;
+        }
+        Ok(())
+    }
+
+    /// Poll for inbound messages and processs them.
+    fn poll_inbound_read(self: &mut Self, cx: &mut Context) -> Result<()> {
+        loop {
+            let msg = Stream::poll_next(Pin::new(&mut self.reader), cx);
+            match msg {
+                Poll::Ready(Some(Ok(message))) => {
+                    self.on_message(message)?;
+                }
+                Poll::Ready(Some(Err(e))) => return Err(e),
+                Poll::Pending | Poll::Ready(None) => return Ok(()),
+            }
+        }
+    }
+
+    /// Write outgoing messages to the network.
+    fn poll_outbound_write(self: &mut Self, cx: &mut Context) -> Result<()> {
+        match Pin::new(&mut self.writer).poll_write_all(cx) {
+            Poll::Pending | Poll::Ready(Ok(_)) => Ok(()),
+            Poll::Ready(Err(e)) => Err(e),
+        }
+    }
+
+    fn on_message(&mut self, buf: Vec<u8>) -> Result<()> {
+        // log::trace!(
+        //     "[{}] onmessage IN len {} state {:?}",
+        //     self.is_initiator(),
+        //     buf.len(),
+        //     self.state
+        // );
+        match self.state {
+            State::Handshake(_) => self.on_handshake_message(buf),
+            State::Established => self.on_proto_message(buf),
+            State::NotInitialized => panic!("cannot receive messages before starting the protocol"),
+        }
     }
 
     fn on_handshake_message(&mut self, buf: Vec<u8>) -> Result<()> {
         let mut handshake = match &mut self.state {
             State::Handshake(handshake) => handshake.take().unwrap(),
-            _ => panic!("cannot call on_handshake_message when not in Handshake state"),
+            _ => panic!("may not call on_handshake_message when not in Handshake state"),
         };
+
         if let Some(response_buf) = handshake.read(&buf)? {
-            self.queue_message(response_buf.to_vec());
+            self.queue_outbound_message(response_buf.to_vec());
         }
+
         if !handshake.complete() {
             self.state = State::Handshake(Some(handshake));
-            Ok(())
         } else {
             let result = handshake.into_result()?;
             if self.options.encrypted {
@@ -413,49 +344,49 @@ where
                 self.writer.upgrade_with_handshake(&result)?;
             }
             let remote_key = result.remote_pubkey.to_vec();
-            log::trace!(
+            log::debug!(
                 "handshake complete, remote_key {}",
                 pretty_hash(&remote_key)
             );
             self.handshake = Some(result);
             self.state = State::Established;
             self.queue_event(Event::Handshake(remote_key));
-            Ok(())
-            // Ok(Some(Event::Handshake(remote_key)))
         }
+        Ok(())
     }
 
     fn on_proto_message(&mut self, buf: Vec<u8>) -> Result<()> {
         let channel_message = ChannelMessage::decode(buf)?;
-        log::trace!("recv {:?}", channel_message);
+        log::debug!("[{}] recv {:?}", self.is_initiator(), channel_message);
         let (remote_id, message) = channel_message.into_split();
         match message {
             Message::Open(msg) => self.on_open(remote_id, msg),
             Message::Close(msg) => self.on_close(remote_id, msg),
             Message::Extension(_msg) => unimplemented!(),
-            _ => self.on_channel_message(remote_id as usize, message),
+            _ => self
+                .channels
+                .forward_inbound_message(remote_id as usize, message),
         }
     }
 
-    /// Open a new protocol channel.
-    ///
-    /// Once the other side proofed that it also knows the `key`, the channel is emitted as
-    /// `Event::Channel` on the protocol event stream.
-    pub fn open(&mut self, key: Vec<u8>) -> Result<()> {
+    fn on_command(&mut self, command: Command) -> Result<()> {
+        match command {
+            Command::Open(key) => self.command_open(key),
+            _ => Ok(()),
+        }
+    }
+
+    fn command_open(&mut self, key: Vec<u8>) -> Result<()> {
         // Create a new channel.
-        let inner_channel = self.channels.attach_local(key.clone());
+        let channel_handle = self.channels.attach_local(key.clone());
         // Safe because attach_local always puts Some(local_id)
-        let local_id = inner_channel.local_id.unwrap();
-        let discovery_key = inner_channel.discovery_key.clone();
+        let local_id = channel_handle.local_id.unwrap();
+        let discovery_key = channel_handle.discovery_key.clone();
 
         // If the channel was already opened from the remote end, verify, and if
         // verification is ok, push a channel open event.
-        if let Some(_remote_id) = inner_channel.remote_id {
-            let remote_capability = inner_channel.remote_capability.clone();
-            self.verify_remote_capability(remote_capability, &key)?;
-            let _channel = self.create_channel(local_id);
-            self.queued_events
-                .push_back(Event::Open(local_id, discovery_key.clone()));
+        if channel_handle.is_connected() {
+            self.accept_channel(local_id)?;
         }
 
         // Tell the remote end about the new channel.
@@ -465,28 +396,23 @@ where
             capability,
         });
         let channel_message = ChannelMessage::new(local_id as u64, message);
-        self.queue_channel_message(channel_message)
+        self.queue_outbound_channel_message(channel_message)
     }
 
     fn on_open(&mut self, ch: u64, msg: Open) -> Result<()> {
-        let inner_channel = self.channels.attach_remote(
+        let channel_handle = self.channels.attach_remote(
             msg.discovery_key.clone(),
             ch as usize,
             msg.capability.clone(),
         );
 
-        // This means there is not yet a locally-opened channel for this discovery_key.
-        if let Some(local_id) = inner_channel.local_id {
-            let key = inner_channel.key.as_ref().unwrap().clone();
-            self.verify_remote_capability(msg.capability.clone(), &key)?;
-
-            let channel = self.create_channel(local_id);
-            let id = channel.id();
-            self.queue_event(Event::Open(id, channel.discovery_key));
-            self.queue_event(Event::Message(id, Message::Open(msg)));
+        if channel_handle.is_connected() {
+            let local_id = channel_handle.local_id.unwrap();
+            self.accept_channel(local_id)?;
         } else {
-            self.queue_event(Event::DiscoveryKey(msg.discovery_key.clone()));
+            self.queue_event(Event::DiscoveryKey(msg.discovery_key));
         }
+
         Ok(())
     }
 
@@ -494,65 +420,47 @@ where
         self.queued_events.push_back(event);
     }
 
-    fn create_channel(&mut self, local_id: usize) -> Channel {
-        let inner_channel = self.channels.get_local_mut(local_id).unwrap();
-        let (channel, send_rx) = inner_channel.open();
-        self.outbound_rx.push(Box::new(send_rx));
-        channel
+    fn queue_outbound_message(&mut self, message: Vec<u8>) {
+        self.writer.queue_message(message);
     }
 
-    fn close_local(&mut self, local_id: u64) {
-        if let Some(channel) = self.channels.get_local_mut(local_id as usize) {
-            let discovery_key = channel.discovery_key.clone();
-            self.channels.remove(&discovery_key);
-            self.queue_event(Event::Close(local_id as usize));
-        }
-    }
-
-    fn on_close(&mut self, remote_id: u64, msg: Close) -> Result<()> {
-        if let Some(channel) = self.channels.get_remote_mut(remote_id as usize) {
-            let discovery_key = channel.discovery_key.clone();
-            if let Some(id) = channel.id() {
-                self.queue_event(Event::Message(id, Message::Close(msg)));
-                self.queue_event(Event::Close(id));
-            }
-            self.channels.remove(&discovery_key);
-        }
-        Ok(())
-    }
-
-    fn on_channel_message(&mut self, remote_id: usize, message: Message) -> Result<()> {
-        if let Some(channel) = self.channels.get_remote_mut(remote_id) {
-            if let Some(id) = channel.id() {
-                self.queue_event(Event::Message(id, message));
-            }
-        }
-        Ok(())
-    }
-
-    fn queue_message(&mut self, message: Vec<u8>) {
-        let prefix = length_prefix(&message);
-        self.queued_messages.push_back(prefix);
-        self.queued_messages.push_back(message);
-    }
-
-    fn queue_channel_message(&mut self, channel_message: ChannelMessage) -> Result<()> {
-        log::trace!("send {:?}", channel_message);
+    fn queue_outbound_channel_message(&mut self, channel_message: ChannelMessage) -> Result<()> {
         let buf = channel_message.encode()?;
-        self.queue_message(buf);
+        self.queue_outbound_message(buf);
         Ok(())
     }
 
     fn queue_ping(&mut self) {
-        self.queued_messages.push_back(vec![0]);
+        self.writer.queue_raw(vec![0]);
     }
 
-    /// Stop the protocol and return the inner reader and writer.
-    pub fn release(self) -> (R, W) {
-        (
-            self.reader.into_inner().into_inner(),
-            self.writer.into_inner().into_inner(),
-        )
+    fn accept_channel(&mut self, local_id: usize) -> Result<()> {
+        let (key, remote_capability) = self.channels.prepare_to_verify(local_id)?;
+        self.verify_remote_capability(remote_capability.cloned(), key)?;
+        let channel = self.channels.accept(local_id)?;
+        self.queue_event(Event::Channel(channel));
+        Ok(())
+    }
+
+    fn close_local(&mut self, local_id: u64) {
+        if let Some(channel) = self.channels.get_local(local_id as usize) {
+            let discovery_key = channel.discovery_key.clone();
+            self.channels.remove(&discovery_key);
+            self.queue_event(Event::Close(discovery_key));
+        }
+    }
+
+    fn on_close(&mut self, remote_id: u64, msg: Close) -> Result<()> {
+        // eprintln!("ON_CLOSE [{}] {}", self.is_initiator(), remote_id);
+        if let Some(channel_handle) = self.channels.get_remote(remote_id as usize) {
+            let discovery_key = channel_handle.discovery_key.clone();
+            self.channels
+                .forward_inbound_message(remote_id as usize, Message::Close(msg))?;
+            self.channels.remove(&discovery_key);
+            // eprintln!("ON_CLOSE OK EMIT [{}] {}", self.is_initiator(), remote_id);
+            self.queue_event(Event::Close(discovery_key));
+        }
+        Ok(())
     }
 
     fn capability(&self, key: &[u8]) -> Option<Vec<u8>> {
@@ -571,116 +479,39 @@ where
             )),
         }
     }
+}
 
-    /// Convert the protocol into a [Stream](futures::io::Stream) of [Event](Event)s.
-    pub fn into_stream(self) -> stream::ProtocolStream<R, W> {
-        let control = self.control();
-        stream::ProtocolStream::new(self, control)
-    }
-
-    /// Get a sender to send control events.
-    pub fn control(&self) -> ControlTx {
-        self.control_tx.clone()
+impl<R, W> Stream for Protocol<R, W>
+where
+    R: AsyncRead + Send + Unpin + 'static,
+    W: AsyncWrite + Send + Unpin + 'static,
+{
+    type Item = Result<Event>;
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        Protocol::poll_next(self, cx).map(Some)
     }
 }
 
-/// A control event for the protocol stream.
-#[derive(Debug)]
-pub enum ControlEvent {
-    Open(Vec<u8>),
-}
-
-/// Send [ControlEvent](ControlEvent)s to the [Protocol](Protocol).
+/// Send [Command](Command)s to the [Protocol](Protocol).
 #[derive(Clone)]
-pub struct ControlTx(Sender<ControlEvent>);
+pub struct CommandTx(Sender<Command>);
 
-impl ControlTx {
+impl CommandTx {
+    pub async fn send(&mut self, command: Command) -> Result<()> {
+        self.0.send(command).await.map_err(map_channel_err)
+    }
     /// Open a protocol channel.
     ///
     /// The channel will be emitted on the main protocol.
-    pub async fn open(&mut self, key: Vec<u8>) -> Result<()> {
-        self.0
-            .send(ControlEvent::Open(key))
-            .await
-            .map_err(map_channel_err)
-    }
-}
-
-pub use stream::ProtocolStream;
-mod stream {
-    use super::ControlTx;
-    use crate::{Event, Protocol};
-    use futures::future::FutureExt;
-    use futures::io::{AsyncRead, AsyncWrite};
-    use futures::stream::Stream;
-    use std::future::Future;
-    use std::io::Result;
-    use std::pin::Pin;
-    use std::task::Poll;
-
-    type LoopFuture<R, W> = Pin<Box<dyn Future<Output = (Result<Event>, Protocol<R, W>)> + Send>>;
-
-    async fn loop_next<R, W>(mut protocol: Protocol<R, W>) -> (Result<Event>, Protocol<R, W>)
-    where
-        R: AsyncRead + Send + Unpin + 'static,
-        W: AsyncWrite + Send + Unpin + 'static,
-    {
-        let event = protocol.loop_next().await;
-        (event, protocol)
+    pub async fn open(&mut self, key: Key) -> Result<()> {
+        self.send(Command::Open(key)).await
     }
 
-    /// Event stream interface for a Protocol instance.
-    pub struct ProtocolStream<R, W>
-    where
-        R: AsyncRead + Send + Unpin + 'static,
-        W: AsyncWrite + Send + Unpin + 'static,
-    {
-        fut: LoopFuture<R, W>,
-        tx: ControlTx,
+    /// Close a protocol channel.
+    pub async fn close(&mut self, discovery_key: DiscoveryKey) -> Result<()> {
+        self.send(Command::Close(discovery_key)).await
     }
-
-    impl<R, W> ProtocolStream<R, W>
-    where
-        R: AsyncRead + Send + Unpin + 'static,
-        W: AsyncWrite + Send + Unpin + 'static,
-    {
-        pub fn new(protocol: Protocol<R, W>, tx: ControlTx) -> Self {
-            let fut = loop_next(protocol).boxed();
-            Self { fut, tx }
-        }
-
-        pub async fn open(&mut self, key: Vec<u8>) -> Result<()> {
-            self.tx.open(key).await
-        }
-    }
-
-    impl<R, W> Stream for ProtocolStream<R, W>
-    where
-        R: AsyncRead + Send + Unpin + 'static,
-        W: AsyncWrite + Send + Unpin + 'static,
-    {
-        type Item = Result<Event>;
-        fn poll_next(
-            mut self: Pin<&mut Self>,
-            cx: &mut std::task::Context<'_>,
-        ) -> Poll<Option<Self::Item>> {
-            let fut = Pin::as_mut(&mut self.fut);
-            match fut.poll(cx) {
-                Poll::Pending => Poll::Pending,
-                Poll::Ready(result) => {
-                    let (result, protocol) = result;
-                    self.fut = loop_next(protocol).boxed();
-                    Poll::Ready(Some(result))
-                }
-            }
-        }
-    }
-}
-
-fn length_prefix(buf: &[u8]) -> Vec<u8> {
-    let len = buf.len();
-    let prefix_len = varinteger::length(len as u64);
-    let mut prefix_buf = vec![0u8; prefix_len];
-    varinteger::encode(len as u64, &mut prefix_buf[..prefix_len]);
-    prefix_buf
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,16 +1,21 @@
 use futures::channel::mpsc::{Receiver, Sender};
-use futures::future::{Fuse, FutureExt};
+use futures::future::FutureExt;
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::io::{BufReader, BufWriter};
+use futures::ready;
 use futures::sink::SinkExt;
-use futures::stream::{SelectAll, Stream, StreamExt};
+use futures::stream::{SelectAll, Stream};
+use futures::task::{Context, Poll};
 use futures_timer::Delay;
 use log::*;
 use std::collections::VecDeque;
 use std::fmt;
+use std::future::Future;
 use std::io::{Error, ErrorKind, Result};
+use std::pin::Pin;
 use std::time::Duration;
 
+use crate::builder::{Builder, Options};
 use crate::channels::{Channel, Channelizer};
 use crate::constants::DEFAULT_KEEPALIVE;
 use crate::message::{ChannelMessage, Message};
@@ -24,18 +29,41 @@ use crate::writer::ProtocolWriter;
 const CHANNEL_CAP: usize = 1000;
 const KEEPALIVE_DURATION: Duration = Duration::from_secs(DEFAULT_KEEPALIVE as u64);
 
+pub type RemotePublicKey = Vec<u8>;
+pub type DiscoveryKey = Vec<u8>;
+pub type Key = Vec<u8>;
+pub type ChannelId = usize;
+
 /// A protocol event.
 pub enum Event {
-    Handshake(Vec<u8>),
-    DiscoveryKey(Vec<u8>),
-    Channel(Channel),
-    Close(Vec<u8>),
+    Handshake(RemotePublicKey),
+    DiscoveryKey(DiscoveryKey),
+    Open(ChannelId, DiscoveryKey),
+    Message(ChannelId, Message),
+    Close(ChannelId),
+    Error(std::io::Error),
 }
 
-// enum Outgoing {
-//     Ping,
-//     Raw(Vec<u8>),
-//     ChannelMessage(ChannelMessage),
+pub enum Action {
+    Open(Key),
+    Close(DiscoveryKey),
+    Send(ChannelId, Message),
+}
+
+// struct Channelizzer<R, W>
+// where
+//     R: AsyncRead + Send + Unpin + 'static,
+//     W: AsyncWrite + Send + Unpin + 'static,
+// {
+//     protocol: Protocol<R, W>,
+// }
+// impl Stream for Channelizer {
+//     type Item = C
+//     fn poll_next(
+//         mut self: Pin<&mut Self>,
+//         cx: &mut std::task::Context<'_>,
+//     ) -> Poll<Option<Self::Item>> {
+//     }
 // }
 
 impl fmt::Debug for Event {
@@ -47,87 +75,13 @@ impl fmt::Debug for Event {
             Event::DiscoveryKey(discovery_key) => {
                 write!(f, "DiscoveryKey({})", &pretty_hash(discovery_key))
             }
-            Event::Close(discovery_key) => write!(f, "Close({})", &pretty_hash(discovery_key)),
-            Event::Channel(channel) => write!(f, "{:?}", channel),
+            Event::Close(channel) => write!(f, "Close({})", channel),
+            Event::Open(channel, discovery_key) => {
+                write!(f, "Open({}, {})", channel, &pretty_hash(discovery_key))
+            }
+            Event::Message(channel, message) => write!(f, "{:?} {:?}", channel, message),
+            Event::Error(error) => write!(f, "{:?}", error),
         }
-    }
-}
-
-/// Options for a Protocol instance.
-#[derive(Debug)]
-pub struct ProtocolOptions {
-    pub is_initiator: bool,
-    pub noise: bool,
-    pub encrypted: bool,
-}
-
-/// Build a Protocol instance with options.
-pub struct ProtocolBuilder(ProtocolOptions);
-
-impl ProtocolBuilder {
-    // Create a protocol builder.
-    pub fn new(is_initiator: bool) -> Self {
-        Self(ProtocolOptions {
-            is_initiator,
-            noise: true,
-            encrypted: true,
-        })
-    }
-
-    /// Default options for an initiating endpoint.
-    pub fn initiator() -> Self {
-        Self::new(true)
-    }
-
-    /// Default options for a responding endpoint.
-    pub fn responder() -> Self {
-        Self::new(false)
-    }
-
-    /// Set encrypted option.
-    pub fn set_encrypted(mut self, encrypted: bool) -> Self {
-        self.0.encrypted = encrypted;
-        self
-    }
-
-    /// Set handshake option.
-    pub fn set_noise(mut self, noise: bool) -> Self {
-        self.0.noise = noise;
-        self
-    }
-
-    /// Create the protocol from a stream that implements AsyncRead + AsyncWrite + Clone.
-    pub fn connect<S>(self, stream: S) -> Protocol<S, S>
-    where
-        S: AsyncRead + AsyncWrite + Send + Unpin + Clone + 'static,
-    {
-        Protocol::new(stream.clone(), stream, self.0)
-    }
-
-    /// Create the protocol from an AsyncRead reader and AsyncWrite writer.
-    pub fn connect_rw<R, W>(self, reader: R, writer: W) -> Protocol<R, W>
-    where
-        R: AsyncRead + Send + Unpin + 'static,
-        W: AsyncWrite + Send + Unpin + 'static,
-    {
-        Protocol::new(reader, writer, self.0)
-    }
-
-    #[deprecated(since = "0.0.1", note = "Use connect_rw")]
-    pub fn build_from_io<R, W>(self, reader: R, writer: W) -> Protocol<R, W>
-    where
-        R: AsyncRead + Send + Unpin + 'static,
-        W: AsyncWrite + Send + Unpin + 'static,
-    {
-        self.connect_rw(reader, writer)
-    }
-
-    #[deprecated(since = "0.0.1", note = "Use connect")]
-    pub fn build_from_stream<S>(self, stream: S) -> Protocol<S, S>
-    where
-        S: AsyncRead + AsyncWrite + Send + Unpin + Clone + 'static,
-    {
-        self.connect(stream)
     }
 }
 
@@ -152,7 +106,7 @@ impl fmt::Debug for State {
 }
 
 /// The output of the set of channel senders.
-type CombinedOutputStream = SelectAll<Box<dyn Stream<Item = ChannelMessage> + Send + Unpin>>;
+type OutboundMessagesReceiver = SelectAll<Box<dyn Stream<Item = ChannelMessage> + Send + Unpin>>;
 
 /// A Protocol stream.
 pub struct Protocol<R, W>
@@ -163,16 +117,19 @@ where
     writer: ProtocolWriter<BufWriter<W>>,
     reader: ProtocolReader<BufReader<R>>,
     state: State,
-    options: ProtocolOptions,
+    options: Options,
     handshake: Option<HandshakeResult>,
     channels: Channelizer,
     error: Option<Error>,
-    outbound_rx: CombinedOutputStream,
+    outbound_rx: OutboundMessagesReceiver,
     control_rx: Receiver<ControlEvent>,
     control_tx: ControlTx,
-    events: VecDeque<Event>,
     // outgoing: VecDeque<Event>,
-    keepalive: Option<Fuse<Delay>>,
+    keepalive: Delay,
+
+    // new fields
+    queued_events: VecDeque<Event>,
+    queued_messages: VecDeque<Vec<u8>>,
 }
 
 impl<R, W> Protocol<R, W>
@@ -181,7 +138,7 @@ where
     W: AsyncWrite + Send + Unpin + 'static,
 {
     /// Create a new Protocol instance.
-    pub fn new(reader: R, writer: W, options: ProtocolOptions) -> Self {
+    pub fn new(reader: R, writer: W, options: Options) -> Self {
         let reader = ProtocolReader::new(BufReader::new(reader));
         let writer = ProtocolWriter::new(BufWriter::new(writer));
         let (control_tx, control_rx) = futures::channel::mpsc::channel(CHANNEL_CAP);
@@ -196,18 +153,21 @@ where
             outbound_rx: SelectAll::new(),
             control_rx,
             control_tx: ControlTx(control_tx),
-            events: VecDeque::new(),
             // outgoing: VecDeque::new(),
-            keepalive: None,
+            keepalive: Delay::new(Duration::from_secs(DEFAULT_KEEPALIVE as u64)),
+            // new fields
+            //
+            queued_events: VecDeque::new(),
+            queued_messages: VecDeque::new(),
         }
     }
 
     /// Create a protocol builder.
-    pub fn builder(is_initiator: bool) -> ProtocolBuilder {
-        ProtocolBuilder::new(is_initiator)
+    pub fn builder(is_initiator: bool) -> Builder {
+        Builder::new(is_initiator)
     }
 
-    async fn init(&mut self) -> Result<()> {
+    fn init(&mut self) -> Result<()> {
         trace!(
             "protocol init, state {:?}, options {:?}",
             self.state,
@@ -222,107 +182,193 @@ where
             let mut handshake = Handshake::new(self.options.is_initiator)?;
             // If the handshake start returns a buffer, send it now.
             if let Some(buf) = handshake.start()? {
-                self.writer.send_prefixed(buf).await?;
+                self.queue_message(buf.to_vec());
             }
             State::Handshake(Some(handshake))
         } else {
             State::Established
         };
 
-        self.reset_keepalive();
+        // self.reset_keepalive();
 
         Ok(())
     }
 
-    fn reset_keepalive(&mut self) {
-        let keepalive_duration = Duration::from_secs(DEFAULT_KEEPALIVE as u64);
-        self.keepalive = Some(Delay::new(keepalive_duration).fuse());
-    }
+    // fn reset_keepalive(&mut self) {
+    //     let keepalive_duration = Duration::from_secs(DEFAULT_KEEPALIVE as u64);
+    //     self.keepalive = Some(Delay::new(keepalive_duration).fuse());
+    // }
 
     pub fn is_initiator(&self) -> bool {
         self.options.is_initiator
     }
 
-    /// Wait for the next protocol event.
-    ///
-    /// This function should be called in a loop until this returns an error.
-    pub async fn loop_next(&mut self) -> Result<Event> {
-        // trace!(
-        //     "[{}] loop_next start, state {:?} events.len {}",
-        //     self.is_initiator(),
-        //     self.state,
-        //     self.events.len()
-        // );
-        if let State::NotInitialized = self.state {
-            self.init().await?;
+    pub fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<Event>> {
+        let this = self.get_mut();
+
+        if let State::NotInitialized = this.state {
+            match this.init() {
+                Ok(_) => {}
+                Err(e) => return Poll::Ready(Err(e)),
+            }
         }
 
-        let mut keepalive = if let Some(keepalive) = self.keepalive.take() {
-            keepalive
-        } else {
-            Delay::new(KEEPALIVE_DURATION).fuse()
-        };
-
-        // Wait for new bytes to arrive, or for the keepalive to occur to send a ping.
-        // If data was received, reset the keepalive timer.
         loop {
-            // trace!("[{}] loop_next loop in", self.is_initiator());
-
-            if let Some(event) = self.events.pop_front() {
-                return Ok(event);
+            // Drain queued events first.
+            if let Some(event) = this.queued_events.pop_front() {
+                return Poll::Ready(Ok(event));
             }
 
-            let event = futures::select! {
-                // Keepalive timer for pings
-                _ = keepalive => {
-                    // trace!("[{}] loop_next ! keepalive", self.is_initiator());
-                    self.ping().await?;
-                    // TODO: It would be better to `reset` the keepalive and not recreate it.
-                    // I couldn't get this to work with `fuse()` though which is needed for
-                    // the `select!` macro.
-                    keepalive = Delay::new(KEEPALIVE_DURATION).fuse();
-                    None
-                },
-                // New wire message incoming
-                buf = self.reader.select_next_some() => {
-                    // trace!("[{}] loop_next ! incoming message", self.is_initiator());
-                    self.on_message(buf?).await?
-                },
-                // New outbound message
-                channel_message = self.outbound_rx.select_next_some() => {
-                    // trace!("[{}] loop_next ! outbound_rx", self.is_initiator());
-                    let event = match channel_message {
-                        ChannelMessage { channel, message: Message::Close(_) } => {
-                            self.close_local(channel).await?
-                        },
-                        _ => None
-                    };
-                    self.send(channel_message).await?;
-                    // trace!("[{}] loop_next ! outbound_rx SENT", self.is_initiator());
-                    event
-                },
-                // New control message
-                ev = self.control_rx.select_next_some() => {
-                    // trace!("[{}] loop_next ! control_rx", self.is_initiator());
-                    match ev {
-                        ControlEvent::Open(key) => {
-                            self.open(key).await?;
-                            None
+            // Send queued messages out.
+            while !this.queued_messages.is_empty() {
+                let res = ready!(Pin::new(&mut this.writer)
+                    .poll_write_message(this.queued_messages.front().unwrap(), cx));
+                this.writer.reset();
+                this.queued_messages.pop_front();
+                if let Err(e) = res {
+                    this.queued_events.push_back(Event::Error(e));
+                    continue;
+                }
+            }
+
+            // Check for outgoing messages.
+            match Pin::new(&mut this.outbound_rx).poll_next(cx) {
+                Poll::Pending => {}
+                // TODO: Can this actually happen?
+                Poll::Ready(None) => {}
+                Poll::Ready(Some(channel_message)) => {
+                    // If message is close, close the local channel.
+                    match channel_message {
+                        ChannelMessage {
+                            channel,
+                            message: Message::Close(_),
+                        } => {
+                            this.close_local(channel);
                         }
+                        _ => {}
+                    };
+                    let res = this.queue_channel_message(channel_message);
+                    match res {
+                        Err(e) => return Poll::Ready(Err(e)),
+                        _ => {}
                     }
-                },
-            };
-            // trace!(
-            //     "[{}] loop_next loop out, event {:?}",
-            //     self.is_initiator(),
-            //     event
-            // );
-            if let Some(event) = event {
-                self.keepalive = Some(keepalive);
-                return Ok(event);
+                }
+            }
+
+            // Poll the keepalive timer.
+            match Future::poll(Pin::new(&mut this.keepalive), cx) {
+                Poll::Pending => {}
+                Poll::Ready(_) => {
+                    this.queue_ping();
+                    this.keepalive.reset(KEEPALIVE_DURATION);
+                }
+            }
+
+            // Wait for incoming messages.
+            while let Poll::Ready(Some(message)) = Stream::poll_next(Pin::new(&mut this.reader), cx)
+            {
+                let res = match message {
+                    Ok(message) => this.on_message(message),
+                    Err(e) => Err(e),
+                };
+                if let Err(e) = res {
+                    this.queued_events.push_back(Event::Error(e));
+                    continue;
+                }
+            }
+
+            // Check if any events are enqueued.
+            if this.queued_events.is_empty() {
+                return Poll::Pending;
             }
         }
     }
+
+    pub async fn loop_next(mut self: &mut Self) -> Result<Event> {
+        let fut = futures::future::poll_fn(move |cx| Protocol::poll_next(Pin::new(&mut self), cx));
+        fut.await
+    }
+
+    /// Wait for the next protocol event.
+    ///
+    /// This function should be called in a loop until this returns an error.
+    // pub async fn loop_next(&mut self) -> Result<Event> {
+    //     // trace!(
+    //     //     "[{}] loop_next start, state {:?} events.len {}",
+    //     //     self.is_initiator(),
+    //     //     self.state,
+    //     //     self.events.len()
+    //     // );
+    //     if let State::NotInitialized = self.state {
+    //         self.init().await?;
+    //     }
+
+    //     let mut keepalive = if let Some(keepalive) = self.keepalive.take() {
+    //         keepalive
+    //     } else {
+    //         Delay::new(KEEPALIVE_DURATION).fuse()
+    //     };
+
+    //     // Wait for new bytes to arrive, or for the keepalive to occur to send a ping.
+    //     // If data was received, reset the keepalive timer.
+    //     loop {
+    //         // trace!("[{}] loop_next loop in", self.is_initiator());
+
+    //         if let Some(event) = self.events.pop_front() {
+    //             return Ok(event);
+    //         }
+
+    //         let event = futures::select! {
+    //             // Keepalive timer for pings
+    //             _ = keepalive => {
+    //                 // trace!("[{}] loop_next ! keepalive", self.is_initiator());
+    //                 self.ping().await?;
+    //                 // TODO: It would be better to `reset` the keepalive and not recreate it.
+    //                 // I couldn't get this to work with `fuse()` though which is needed for
+    //                 // the `select!` macro.
+    //                 keepalive = Delay::new(KEEPALIVE_DURATION).fuse();
+    //                 None
+    //             },
+    //             // New wire message incoming
+    //             buf = self.reader.select_next_some() => {
+    //                 // trace!("[{}] loop_next ! incoming message", self.is_initiator());
+    //                 self.on_message(buf?).await?
+    //             },
+    //             // New outbound message
+    //             channel_message = self.outbound_rx.select_next_some() => {
+    //                 // trace!("[{}] loop_next ! outbound_rx", self.is_initiator());
+    //                 let event = match channel_message {
+    //                     ChannelMessage { channel, message: Message::Close(_) } => {
+    //                         self.close_local(channel).await?
+    //                     },
+    //                     _ => None
+    //                 };
+    //                 self.send(channel_message).await?;
+    //                 // trace!("[{}] loop_next ! outbound_rx SENT", self.is_initiator());
+    //                 event
+    //             },
+    //             // New control message
+    //             ev = self.control_rx.select_next_some() => {
+    //                 // trace!("[{}] loop_next ! control_rx", self.is_initiator());
+    //                 match ev {
+    //                     ControlEvent::Open(key) => {
+    //                         self.open(key).await?;
+    //                         None
+    //                     }
+    //                 }
+    //             },
+    //         };
+    //         // trace!(
+    //         //     "[{}] loop_next loop out, event {:?}",
+    //         //     self.is_initiator(),
+    //         //     event
+    //         // );
+    //         if let Some(event) = event {
+    //             self.keepalive = Some(keepalive);
+    //             return Ok(event);
+    //         }
+    //     }
+    // }
 
     /// Get the peer's Noise public key.
     ///
@@ -339,26 +385,27 @@ where
         self.error = Some(error)
     }
 
-    async fn on_message(&mut self, buf: Vec<u8>) -> Result<Option<Event>> {
+    fn on_message(&mut self, buf: Vec<u8>) -> Result<()> {
         // trace!("onmessage, state {:?} msg len {}", self.state, buf.len());
         match self.state {
-            State::Handshake(_) => self.on_handshake_message(buf).await,
-            State::Established => self.on_proto_message(buf).await,
+            State::Handshake(_) => self.on_handshake_message(buf)?,
+            State::Established => self.on_proto_message(buf)?,
             State::NotInitialized => panic!("cannot receive messages before starting the protocol"),
-        }
+        };
+        Ok(())
     }
 
-    async fn on_handshake_message(&mut self, buf: Vec<u8>) -> Result<Option<Event>> {
+    fn on_handshake_message(&mut self, buf: Vec<u8>) -> Result<()> {
         let mut handshake = match &mut self.state {
             State::Handshake(handshake) => handshake.take().unwrap(),
             _ => panic!("cannot call on_handshake_message when not in Handshake state"),
         };
         if let Some(response_buf) = handshake.read(&buf)? {
-            self.writer.send_prefixed(response_buf).await?;
+            self.queue_message(response_buf.to_vec());
         }
         if !handshake.complete() {
             self.state = State::Handshake(Some(handshake));
-            Ok(None)
+            Ok(())
         } else {
             let result = handshake.into_result()?;
             if self.options.encrypted {
@@ -372,22 +419,21 @@ where
             );
             self.handshake = Some(result);
             self.state = State::Established;
-            Ok(Some(Event::Handshake(remote_key)))
+            self.queue_event(Event::Handshake(remote_key));
+            Ok(())
+            // Ok(Some(Event::Handshake(remote_key)))
         }
     }
 
-    async fn on_proto_message(&mut self, buf: Vec<u8>) -> Result<Option<Event>> {
+    fn on_proto_message(&mut self, buf: Vec<u8>) -> Result<()> {
         let channel_message = ChannelMessage::decode(buf)?;
         log::trace!("recv {:?}", channel_message);
         let (remote_id, message) = channel_message.into_split();
         match message {
-            Message::Open(msg) => self.open_remote(remote_id, msg).await,
-            Message::Close(msg) => self.close_remote(remote_id, msg).await,
+            Message::Open(msg) => self.on_open(remote_id, msg),
+            Message::Close(msg) => self.on_close(remote_id, msg),
             Message::Extension(_msg) => unimplemented!(),
-            _ => {
-                self.channels.forward(remote_id as usize, message).await?;
-                Ok(None)
-            }
+            _ => self.on_channel_message(remote_id as usize, message),
         }
     }
 
@@ -395,7 +441,7 @@ where
     ///
     /// Once the other side proofed that it also knows the `key`, the channel is emitted as
     /// `Event::Channel` on the protocol event stream.
-    pub async fn open(&mut self, key: Vec<u8>) -> Result<()> {
+    pub fn open(&mut self, key: Vec<u8>) -> Result<()> {
         // Create a new channel.
         let inner_channel = self.channels.attach_local(key.clone());
         // Safe because attach_local always puts Some(local_id)
@@ -407,8 +453,9 @@ where
         if let Some(_remote_id) = inner_channel.remote_id {
             let remote_capability = inner_channel.remote_capability.clone();
             self.verify_remote_capability(remote_capability, &key)?;
-            let channel = self.create_channel(local_id).await?;
-            self.events.push_back(Event::Channel(channel));
+            let _channel = self.create_channel(local_id);
+            self.queued_events
+                .push_back(Event::Open(local_id, discovery_key.clone()));
         }
 
         // Tell the remote end about the new channel.
@@ -418,14 +465,10 @@ where
             capability,
         });
         let channel_message = ChannelMessage::new(local_id as u64, message);
-        self.outbound_rx.push(Box::new(
-            futures::future::ready(channel_message).into_stream(),
-        ));
-
-        Ok(())
+        self.queue_channel_message(channel_message)
     }
 
-    async fn open_remote(&mut self, ch: u64, msg: Open) -> Result<Option<Event>> {
+    fn on_open(&mut self, ch: u64, msg: Open) -> Result<()> {
         let inner_channel = self.channels.attach_remote(
             msg.discovery_key.clone(),
             ch as usize,
@@ -435,51 +478,73 @@ where
         // This means there is not yet a locally-opened channel for this discovery_key.
         if let Some(local_id) = inner_channel.local_id {
             let key = inner_channel.key.as_ref().unwrap().clone();
-            self.verify_remote_capability(msg.capability, &key)?;
-            let channel = self.create_channel(local_id).await?;
-            Ok(Some(Event::Channel(channel)))
+            self.verify_remote_capability(msg.capability.clone(), &key)?;
+
+            let channel = self.create_channel(local_id);
+            let id = channel.id();
+            self.queue_event(Event::Open(id, channel.discovery_key));
+            self.queue_event(Event::Message(id, Message::Open(msg)));
         } else {
-            Ok(Some(Event::DiscoveryKey(msg.discovery_key.clone())))
+            self.queue_event(Event::DiscoveryKey(msg.discovery_key.clone()));
         }
+        Ok(())
     }
 
-    async fn create_channel(&mut self, local_id: usize) -> Result<Channel> {
+    fn queue_event(&mut self, event: Event) {
+        self.queued_events.push_back(event);
+    }
+
+    fn create_channel(&mut self, local_id: usize) -> Channel {
         let inner_channel = self.channels.get_local_mut(local_id).unwrap();
-        let (channel, send_rx) = inner_channel.open().await?;
+        let (channel, send_rx) = inner_channel.open();
         self.outbound_rx.push(Box::new(send_rx));
-        Ok(channel)
+        channel
     }
 
-    async fn close_local(&mut self, local_id: u64) -> Result<Option<Event>> {
+    fn close_local(&mut self, local_id: u64) {
         if let Some(channel) = self.channels.get_local_mut(local_id as usize) {
             let discovery_key = channel.discovery_key.clone();
-            channel.recv_close(None).await?;
             self.channels.remove(&discovery_key);
-            Ok(Some(Event::Close(discovery_key)))
-        } else {
-            Ok(None)
+            self.queue_event(Event::Close(local_id as usize));
         }
     }
 
-    async fn close_remote(&mut self, remote_id: u64, msg: Close) -> Result<Option<Event>> {
+    fn on_close(&mut self, remote_id: u64, msg: Close) -> Result<()> {
         if let Some(channel) = self.channels.get_remote_mut(remote_id as usize) {
             let discovery_key = channel.discovery_key.clone();
-            channel.recv_close(Some(msg)).await?;
+            if let Some(id) = channel.id() {
+                self.queue_event(Event::Message(id, Message::Close(msg)));
+                self.queue_event(Event::Close(id));
+            }
             self.channels.remove(&discovery_key);
-            Ok(Some(Event::Close(discovery_key)))
-        } else {
-            Ok(None)
         }
+        Ok(())
     }
 
-    async fn send(&mut self, channel_message: ChannelMessage) -> Result<()> {
+    fn on_channel_message(&mut self, remote_id: usize, message: Message) -> Result<()> {
+        if let Some(channel) = self.channels.get_remote_mut(remote_id) {
+            if let Some(id) = channel.id() {
+                self.queue_event(Event::Message(id, message));
+            }
+        }
+        Ok(())
+    }
+
+    fn queue_message(&mut self, message: Vec<u8>) {
+        let prefix = length_prefix(&message);
+        self.queued_messages.push_back(prefix);
+        self.queued_messages.push_back(message);
+    }
+
+    fn queue_channel_message(&mut self, channel_message: ChannelMessage) -> Result<()> {
         log::trace!("send {:?}", channel_message);
         let buf = channel_message.encode()?;
-        self.writer.send_prefixed(&buf).await
+        self.queue_message(buf);
+        Ok(())
     }
 
-    async fn ping(&mut self) -> Result<()> {
-        self.writer.ping().await
+    fn queue_ping(&mut self) {
+        self.queued_messages.push_back(vec![0]);
     }
 
     /// Stop the protocol and return the inner reader and writer.
@@ -610,4 +675,12 @@ mod stream {
             }
         }
     }
+}
+
+fn length_prefix(buf: &[u8]) -> Vec<u8> {
+    let len = buf.len();
+    let prefix_len = varinteger::length(len as u64);
+    let mut prefix_buf = vec![0u8; prefix_len];
+    varinteger::encode(len as u64, &mut prefix_buf[..prefix_len]);
+    prefix_buf
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,9 +13,17 @@ pub fn pretty_hash(key: &[u8]) -> String {
     pretty_hash::fmt(key).unwrap_or_else(|_| "<invalid>".into())
 }
 
-pub fn map_channel_err(err: futures::channel::mpsc::SendError) -> Error {
+pub fn map_channel_err<T>(err: async_channel::SendError<T>) -> Error {
     Error::new(
         ErrorKind::BrokenPipe,
         format!("Cannot forward on channel: {}", err),
     )
+}
+
+pub fn length_prefix(buf: &[u8]) -> Vec<u8> {
+    let len = buf.len();
+    let prefix_len = varinteger::length(len as u64);
+    let mut prefix_buf = vec![0u8; prefix_len];
+    varinteger::encode(len as u64, &mut prefix_buf[..prefix_len]);
+    prefix_buf
 }

--- a/tests/_util.rs
+++ b/tests/_util.rs
@@ -1,0 +1,77 @@
+use async_std::net::TcpStream;
+use async_std::prelude::*;
+use async_std::task;
+use futures::io::{AsyncRead, AsyncWrite};
+use hypercore_protocol::{Channel, Event, Protocol, ProtocolBuilder};
+
+pub type MemoryProtocol = Protocol<sluice::pipe::PipeReader, sluice::pipe::PipeWriter>;
+pub async fn create_pair_memory() -> std::io::Result<(MemoryProtocol, MemoryProtocol)> {
+    let (ar, bw) = sluice::pipe::pipe();
+    let (br, aw) = sluice::pipe::pipe();
+
+    let a = ProtocolBuilder::new(true);
+    let b = ProtocolBuilder::new(false);
+    let a = a.connect_rw(ar, aw);
+    let b = b.connect_rw(br, bw);
+    Ok((a, b))
+}
+
+pub type TcpProtocol = Protocol<TcpStream, TcpStream>;
+pub async fn create_pair_tcp() -> std::io::Result<(TcpProtocol, TcpProtocol)> {
+    let (stream_a, stream_b) = tcp::pair().await?;
+    let a = ProtocolBuilder::new(true).connect(stream_a);
+    let b = ProtocolBuilder::new(false).connect(stream_b);
+    Ok((a, b))
+}
+
+pub fn next_event<R, W>(
+    mut proto: Protocol<R, W>,
+) -> impl Future<Output = (std::io::Result<Event>, Protocol<R, W>)>
+where
+    R: AsyncRead + Send + Unpin,
+    W: AsyncWrite + Send + Unpin,
+{
+    let task = task::spawn(async move {
+        let e1 = proto.next().await;
+        let e1 = e1.unwrap();
+        (e1, proto)
+    });
+    task
+}
+
+pub fn event_discovery_key(event: Event) -> Vec<u8> {
+    if let Event::DiscoveryKey(dkey) = event {
+        dkey
+    } else {
+        panic!("Expected discovery key event");
+    }
+}
+
+pub fn event_channel(event: Event) -> Channel {
+    if let Event::Channel(channel) = event {
+        channel
+    } else {
+        panic!("Expected channel event");
+    }
+}
+
+pub mod tcp {
+    use async_std::net::{TcpListener, TcpStream};
+    use async_std::prelude::*;
+    use async_std::task;
+    use std::io::{Error, ErrorKind, Result};
+    pub async fn pair() -> Result<(TcpStream, TcpStream)> {
+        let address = "localhost:9999";
+        let listener = TcpListener::bind(&address).await?;
+        let mut incoming = listener.incoming();
+
+        let connect_task = task::spawn(async move { TcpStream::connect(&address).await });
+
+        let server_stream = incoming.next().await;
+        let server_stream =
+            server_stream.ok_or_else(|| Error::new(ErrorKind::Other, "Stream closed"))?;
+        let server_stream = server_stream?;
+        let client_stream = connect_task.await?;
+        Ok((server_stream, client_stream))
+    }
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,107 @@
+#![allow(dead_code, unused_imports)]
+
+use async_std::net::TcpStream;
+use async_std::prelude::*;
+use async_std::task;
+use futures::io::{AsyncRead, AsyncWrite};
+use hypercore_protocol::schema::*;
+use hypercore_protocol::{discovery_key, Channel, Event, Message, Protocol, ProtocolBuilder};
+
+mod _util;
+use _util::*;
+
+#[async_std::test]
+async fn basic_protocol() -> anyhow::Result<()> {
+    env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    let (proto_a, proto_b) = create_pair_memory().await?;
+
+    let next_a = next_event(proto_a);
+    let next_b = next_event(proto_b);
+    let (event_a, mut proto_a) = next_a.await;
+    let (event_b, proto_b) = next_b.await;
+
+    assert!(matches!(event_a, Ok(Event::Handshake(_))));
+    assert!(matches!(event_b, Ok(Event::Handshake(_))));
+
+    assert_eq!(proto_a.public_key(), proto_b.remote_public_key());
+    assert_eq!(proto_b.public_key(), proto_a.remote_public_key());
+
+    let key = vec![3u8; 32];
+
+    proto_a.open(key.clone()).await?;
+
+    let next_a = next_event(proto_a);
+    let next_b = next_event(proto_b);
+
+    let (event_b, mut proto_b) = next_b.await;
+    assert!(matches!(event_b, Ok(Event::DiscoveryKey(_))));
+    assert_eq!(event_discovery_key(event_b.unwrap()), discovery_key(&key));
+
+    proto_b.open(key.clone()).await?;
+
+    let next_b = next_event(proto_b);
+    let (event_b, proto_b) = next_b.await;
+    assert!(matches!(event_b, Ok(Event::Channel(_))));
+    let mut channel_b = event_channel(event_b.unwrap());
+
+    let (event_a, proto_a) = next_a.await;
+    assert!(matches!(event_a, Ok(Event::Channel(_))));
+    let mut channel_a = event_channel(event_a.unwrap());
+
+    assert_eq!(channel_a.discovery_key(), channel_b.discovery_key());
+
+    channel_a
+        .want(Want {
+            start: 0,
+            length: Some(10),
+        })
+        .await?;
+
+    channel_b
+        .want(Want {
+            start: 10,
+            length: Some(5),
+        })
+        .await?;
+
+    let next_a = next_event(proto_a);
+    let next_b = next_event(proto_b);
+
+    let channel_event_b = channel_b.next().await;
+    assert_eq!(
+        channel_event_b,
+        Some(Message::Want(Want {
+            start: 0,
+            length: Some(10)
+        }))
+    );
+    // eprintln!("channel_event_b: {:?}", channel_event_b);
+
+    let channel_event_a = channel_a.next().await;
+    assert_eq!(
+        channel_event_a,
+        Some(Message::Want(Want {
+            start: 10,
+            length: Some(5)
+        }))
+    );
+
+    channel_a
+        .close(Close {
+            discovery_key: None,
+        })
+        .await?;
+    channel_b
+        .close(Close {
+            discovery_key: None,
+        })
+        .await?;
+
+    let (event_a, _proto_a) = next_a.await;
+    let (event_b, _proto_b) = next_b.await;
+
+    assert!(matches!(event_a, Ok(Event::Close(_))));
+    assert!(matches!(event_b, Ok(Event::Close(_))));
+
+    return Ok(());
+}


### PR DESCRIPTION
This is a first major refactor in the internals to use poll functions and not async functions internally.

This PR removes all internal async functions from the Protocol struct and instead uses manually implemented poll functions.
It also adds a `commands()` function that gives a handle to the main protocol to send commands to it. The handle can be sent to other threads.

The PR also includes other changes:
* The `ProtocolStream` wrapper is made obsolete, the `Protocol` struct directly implements `Stream`
* Refactored the ChannelMap struct
* Add a first full test
* Update dependencies
* Fix examples