### PR TITLE
Refactor reader and fix unneeded memcpys.

### DIFF
--- a/src/noise/cipher.rs
+++ b/src/noise/cipher.rs
@@ -9,6 +9,12 @@ const NONCE_SIZE: usize = 24;
 
 pub struct Cipher(XSalsa20);
 
+impl std::fmt::Debug for Cipher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Cipher(XSalsa20)")
+    }
+}
+
 impl Cipher {
     pub fn from_handshake_rx(handshake: &HandshakeResult) -> Result<Self> {
         let cipher = XSalsa20::new_var(


### PR DESCRIPTION
Before the reader had a performance bug where it would allocate and copy the full read buffer on each message. Now this only happens once the read buffer filled up. Also the new structure is much simpler and better to follow. 

There's still a few allocations to save possibly, but now this is not a performance leak anymore.