### PR TITLE
Refactor Writer to not allocate for each message.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ bench = false
 [dependencies]
 async-channel = "1.5"
 snow = { version = "0.7.0-alpha5", features = ["risky-raw-split"] }
-prost = "0.6"
-bytes = "0.5"
+prost = "0.7"
+bytes = "1.0.1"
 varinteger = "1.0"
 rand = "0.7"
 blake2-rfc = "0.2"

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,11 +21,3 @@ pub fn map_channel_err<T>(err: async_channel::SendError<T>) -> Error {
         format!("Cannot forward on channel: {}", err),
     )
 }
-
-pub fn length_prefix(buf: &[u8]) -> Vec<u8> {
-    let len = buf.len();
-    let prefix_len = varinteger::length(len as u64);
-    let mut prefix_buf = vec![0u8; prefix_len];
-    varinteger::encode(len as u64, &mut prefix_buf[..prefix_len]);
-    prefix_buf
-}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,19 +1,21 @@
+use crate::message::{EncodeError, Encoder, Frame};
 use crate::noise::{Cipher, HandshakeResult};
-use crate::util::length_prefix;
-use futures_lite::io::AsyncWrite;
-use futures_lite::ready;
+use futures_lite::{ready, AsyncWrite};
+use std::collections::VecDeque;
+use std::fmt;
+use std::io::Result;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::{collections::VecDeque, io::Result};
+
+const BUF_SIZE: usize = 1024 * 64;
 
 pub struct ProtocolWriter<W>
 where
     W: AsyncWrite + Send + Unpin + 'static,
 {
-    cipher: Option<Cipher>,
     writer: W,
-    pos: usize,
-    queue: VecDeque<Vec<u8>>,
+    queue: VecDeque<Frame>,
+    state: State,
 }
 
 impl<W> ProtocolWriter<W>
@@ -22,57 +24,43 @@ where
 {
     pub fn new(writer: W) -> Self {
         Self {
-            cipher: None,
             writer,
-            pos: 0,
+            state: State::new(),
             queue: VecDeque::new(),
         }
     }
 
-    pub fn queue_message(&mut self, message: Vec<u8>) {
-        let prefix = length_prefix(&message);
-        self.queue_raw(prefix);
-        self.queue_raw(message)
+    pub fn queue_frame<F>(&mut self, frame: F)
+    where
+        F: Into<Frame>,
+    {
+        self.queue.push_back(frame.into())
     }
 
-    pub fn queue_raw(&mut self, mut message: Vec<u8>) {
-        self.encrypt(&mut message);
-        self.queue.push_back(message);
+    pub fn can_park_frame(&self) -> bool {
+        self.state.can_park_frame()
     }
 
-    pub fn poll_write_all(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<()>> {
+    pub fn park_frame<F>(&mut self, frame: F)
+    where
+        F: Into<Frame>,
+    {
+        self.state.park_frame(frame)
+    }
+
+    pub fn try_queue_direct<T: Encoder>(
+        &mut self,
+        frame: &T,
+    ) -> std::result::Result<bool, EncodeError> {
+        self.state.try_queue_direct(frame)
+    }
+
+    pub fn poll_send(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<()>> {
         let this = self.get_mut();
-        while let Some(message) = this.queue.pop_front() {
-            match this.poll_write_message(&message, cx) {
-                Poll::Ready(Ok(_)) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => {
-                    this.queue.push_front(message);
-                    return Poll::Pending;
-                }
-            }
-        }
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_write_message(
-        mut self: &mut Self,
-        message: &[u8],
-        cx: &mut Context,
-    ) -> Poll<Result<()>> {
-        while self.pos < message.len() {
-            let pos = self.pos;
-            let n = ready!(Pin::new(&mut self.writer).poll_write(cx, &message[pos..]));
-            let n = n?;
-            self.pos += n;
-        }
-        let res = ready!(Pin::new(&mut self.writer).poll_flush(cx));
-        self.reset();
-        Poll::Ready(res)
-    }
-
-    fn reset(self: &mut Self) {
-        self.pos = 0;
+        let state = &mut this.state;
+        let writer = &mut this.writer;
+        let queue = &mut this.queue;
+        state.poll_send(cx, writer, queue)
     }
 
     pub fn into_inner(self) -> W {
@@ -80,14 +68,143 @@ where
     }
 
     pub fn upgrade_with_handshake(&mut self, handshake: &HandshakeResult) -> Result<()> {
+        self.state.upgrade_with_handshake(handshake)
+    }
+}
+
+#[derive(Debug)]
+pub enum Step {
+    Flushing,
+    Writing,
+    Processing,
+}
+
+pub struct State {
+    buf: Vec<u8>,
+    current_frame: Option<Frame>,
+    start: usize,
+    end: usize,
+    cipher: Option<Cipher>,
+    step: Step,
+}
+
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("State")
+            .field("step", &self.step)
+            .field("buf (len)", &self.buf.len())
+            .field("current_frame", &self.current_frame)
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .field("cipher", &self.cipher.is_some())
+            .finish()
+    }
+}
+
+impl State {
+    fn new() -> Self {
+        Self {
+            buf: vec![0u8; BUF_SIZE],
+            current_frame: None,
+            start: 0,
+            end: 0,
+            cipher: None,
+            step: Step::Processing,
+        }
+    }
+
+    fn try_queue_direct<T: Encoder>(
+        &mut self,
+        frame: &T,
+    ) -> std::result::Result<bool, EncodeError> {
+        let len = frame.encoded_len();
+        if self.buf.len() < len {
+            self.buf.resize(len, 0u8);
+        }
+        if len > self.remaining() {
+            return Ok(false);
+        }
+        let len = frame.encode(&mut self.buf[self.end..])?;
+        self.advance(len);
+        Ok(true)
+    }
+
+    fn can_park_frame(&self) -> bool {
+        self.current_frame.is_none()
+    }
+
+    fn park_frame<F>(&mut self, frame: F)
+    where
+        F: Into<Frame>,
+    {
+        if self.current_frame.is_none() {
+            self.current_frame = Some(frame.into())
+        }
+    }
+
+    fn advance(&mut self, n: usize) {
+        let end = self.end + n;
+        if let Some(ref mut cipher) = self.cipher {
+            cipher.apply(&mut self.buf[self.end..end]);
+        }
+        self.end = end;
+    }
+
+    fn upgrade_with_handshake(&mut self, handshake: &HandshakeResult) -> Result<()> {
         let cipher = Cipher::from_handshake_tx(handshake)?;
         self.cipher = Some(cipher);
         Ok(())
     }
+    fn remaining(&self) -> usize {
+        self.buf.len() - self.end
+    }
 
-    fn encrypt(&mut self, mut buf: &mut [u8]) {
-        if let Some(ref mut cipher) = &mut self.cipher {
-            cipher.apply(&mut buf);
+    fn pending(&self) -> usize {
+        self.end - self.start
+    }
+
+    fn poll_send<W>(
+        &mut self,
+        cx: &mut Context,
+        mut writer: &mut W,
+        queue: &mut VecDeque<Frame>,
+    ) -> Poll<Result<()>>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        loop {
+            self.step = match self.step {
+                Step::Processing => {
+                    if self.current_frame.is_none() && !queue.is_empty() {
+                        self.current_frame = queue.pop_front();
+                    }
+
+                    if let Some(frame) = self.current_frame.take() {
+                        if !self.try_queue_direct(&frame)? {
+                            self.current_frame = Some(frame);
+                        }
+                    }
+                    if self.pending() == 0 {
+                        return Poll::Ready(Ok(()));
+                    }
+                    Step::Writing
+                }
+                Step::Writing => {
+                    let n = ready!(
+                        Pin::new(&mut writer).poll_write(cx, &self.buf[self.start..self.end])
+                    )?;
+                    self.start += n;
+                    if self.start == self.end {
+                        self.start = 0;
+                        self.end = 0;
+                    }
+                    Step::Flushing
+                }
+                Step::Flushing => {
+                    ready!(Pin::new(&mut writer).poll_flush(cx))?;
+                    Step::Processing
+                }
+            }
         }
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -12,7 +12,7 @@ use _util::*;
 
 #[async_std::test]
 async fn basic_protocol() -> anyhow::Result<()> {
-    env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    env_logger::init();
     let (proto_a, proto_b) = create_pair_memory().await?;
 
     let next_a = next_event(proto_a);


### PR DESCRIPTION
- This turned out to be a bigger refactor than expected. The writer now
has a single, adaptive write buffer and does not allocate per message.
Instead the message is copied to the write buffer when encoding.

- Adds a new Frame abstraction to deal with handshake, ping and channel
  messages.

- The new Writer struct supports three methods of sending frames:
  1) Append directly to the write buffer iwth `try_queue_direct`. Fails if the
     write buffer is full. This is used for handshake messages because
     they have to be written before the encryption is set up after
     a successfull handshake.
  2) Push messages into an unbounded high-priority queue with
     `queue_frame`. This is used for messages generated via commands to
     the protocol.
  3) Park a message in the single park slot. This is used to store the
     result from polling the outbound_rx receiver.