### PR TITLE
Extensions

### DIFF
--- a/examples/extension.rs
+++ b/examples/extension.rs
@@ -2,28 +2,134 @@ use async_std::net::TcpStream;
 use async_std::prelude::*;
 use async_std::task::{self, JoinHandle};
 use futures_lite::io::{AsyncRead, AsyncWrite};
-use hypercore_protocol::{Channel, DiscoveryKey, Event, Protocol, ProtocolBuilder};
+use hypercore_protocol::{Channel, Event, Protocol, ProtocolBuilder};
 use log::*;
 use pretty_bytes::converter::convert as pretty_bytes;
 use std::io;
 use std::time::Instant;
 
-pub type MemoryProtocol = Protocol<sluice::pipe::PipeReader, sluice::pipe::PipeWriter>;
-pub async fn create_pair_memory() -> std::io::Result<(MemoryProtocol, MemoryProtocol)> {
-    let (ar, bw) = sluice::pipe::pipe();
-    let (br, aw) = sluice::pipe::pipe();
+// This example sets up a pair of protocols connected over TCP,
+// registers the same extension on each, and then uses the AsyncWrite
+// and AsyncRead implementations on the extension to pipe binary data
+// from A to B, where B will echo it back, and then A will read the
+// echoed stream. Then, the throughput is calculated and reported.
+//
+// Note: Run in release mode, otherwise it will be *very* slow.
+//
+// Adjust the consts below for different "settings".
 
-    let a = ProtocolBuilder::new(true);
-    let b = ProtocolBuilder::new(false);
-    let a = a.connect_rw(ar, aw);
-    let b = b.connect_rw(br, bw);
-    Ok((a, b))
+const BYTES: usize = 1024 * 1024 * 64;
+const PARALLEL: usize = 5;
+const ENCRYPT: bool = false;
+
+#[async_std::main]
+pub async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let port = 9000u16;
+    let mut tasks = vec![];
+    let instant = Instant::now();
+    for n in 0..PARALLEL {
+        let port = port + n as u16;
+        let task = task::spawn(async move {
+            let _ = channel_extension_async_read_write(BYTES, port, ENCRYPT).await;
+        });
+        tasks.push(task);
+    }
+    for task in tasks.iter_mut() {
+        task.await;
+    }
+    print_stats("total", instant, (BYTES * PARALLEL) as f64);
+    Ok(())
+}
+
+async fn channel_extension_async_read_write(
+    limit: usize,
+    port: u16,
+    encrypted: bool,
+) -> anyhow::Result<()> {
+    // let (mut proto_a, mut proto_b) = create_pair_memory().await?;
+    let (mut proto_a, mut proto_b) = create_pair_tcp(port, encrypted).await?;
+    let key = [1u8; 32];
+    proto_a.open(key).await?;
+    proto_b.open(key).await?;
+
+    let next_a = drive_until_channel(proto_a);
+    let next_b = drive_until_channel(proto_b);
+    let (proto_a, mut channel_a) = next_a.await?;
+    let (proto_b, mut channel_b) = next_b.await?;
+
+    let mut ext_a = channel_a.register_extension("ext").await;
+    let mut ext_b = channel_b.register_extension("ext").await;
+
+    // Drive the protocols and channels.
+    drive(proto_a);
+    drive(proto_b);
+    drive(channel_a);
+    drive(channel_b);
+
+    let instant = Instant::now();
+
+    // On B, run an echo loop.
+    task::spawn(async move {
+        let mut read_buf = vec![0u8; 1024 * 64];
+        let mut len = 0;
+        loop {
+            let n = ext_b.read(&mut read_buf).await.unwrap();
+            len += n;
+            debug!("B READ: {}", len);
+            ext_b.write_all(&read_buf[..n]).await.unwrap();
+        }
+    });
+
+    // On A, write BYTES bytes.
+    let mut len = 0;
+    task::spawn({
+        let mut ext_a = ext_a.clone();
+        let buf = vec![0u8; 1024 * 64];
+        async move {
+            while len < limit + 10 {
+                ext_a.write_all(&buf).await.unwrap();
+                len += buf.len();
+                debug!("A WRITE: {}", len);
+            }
+        }
+    });
+
+    // On A, read BYTES bytes back (from the echo on B).
+    let mut read_buf = vec![0u8; 1024 * 64];
+    let mut len = 0;
+    while len < limit {
+        let n = ext_a.read(&mut read_buf).await.unwrap();
+        len += n;
+        debug!("A READ {}", len);
+    }
+
+    // Now report how long it all took.
+    print_stats("done", instant, limit as f64);
+    Ok(())
+}
+
+fn print_stats(msg: impl ToString, instant: Instant, bytes: f64) {
+    let msg = msg.to_string();
+    let time = instant.elapsed();
+    let secs = time.as_secs_f64();
+    let bs = bytes / secs;
+    eprintln!(
+        "[{}] time {:.3?} bytes {} throughput {}/s",
+        msg,
+        time,
+        pretty_bytes(bytes),
+        pretty_bytes(bs)
+    );
 }
 
 pub type TcpProtocol = Protocol<TcpStream, TcpStream>;
-pub async fn create_pair_tcp(port: u16) -> std::io::Result<(TcpProtocol, TcpProtocol)> {
+pub async fn create_pair_tcp(
+    port: u16,
+    encrypted: bool,
+) -> std::io::Result<(TcpProtocol, TcpProtocol)> {
     let (stream_a, stream_b) = tcp::pair(port).await?;
-    let encrypted = true;
     let a = ProtocolBuilder::new(true)
         .set_encrypted(encrypted)
         .connect(stream_a);
@@ -33,56 +139,13 @@ pub async fn create_pair_tcp(port: u16) -> std::io::Result<(TcpProtocol, TcpProt
     Ok((a, b))
 }
 
-pub fn next_event<R, W>(
-    mut proto: Protocol<R, W>,
-) -> impl Future<Output = (std::io::Result<Event>, Protocol<R, W>)>
-where
-    R: AsyncRead + Send + Unpin,
-    W: AsyncWrite + Send + Unpin,
-{
-    let task = task::spawn(async move {
-        let e1 = proto.next().await;
-        let e1 = e1.unwrap();
-        (e1, proto)
-    });
-    task
-}
-
-pub fn event_discovery_key(event: Event) -> DiscoveryKey {
-    if let Event::DiscoveryKey(dkey) = event {
-        dkey
-    } else {
-        panic!("Expected discovery key event");
-    }
-}
-
-pub fn event_channel(event: Event) -> Channel {
-    if let Event::Channel(channel) = event {
-        channel
-    } else {
-        panic!("Expected channel event");
-    }
-}
-// Drive a stream to completion in a task.
+/// Drive a stream to completion in a task.
 fn drive<S>(mut proto: S) -> JoinHandle<()>
 where
     S: Stream + Send + Unpin + 'static,
 {
     task::spawn(async move { while let Some(_event) = proto.next().await {} })
 }
-
-// Drive a number of streams to completion.
-// fn drive_all<S>(streams: Vec<S>) -> JoinHandle<()>
-// where
-//     S: Stream + Send + Unpin + 'static,
-// {
-//     let join_handles = streams.into_iter().map(drive);
-//     task::spawn(async move {
-//         for join_handle in join_handles {
-//             join_handle.await;
-//         }
-//     })
-// }
 
 // Drive a protocol stream until the first channel arrives.
 fn drive_until_channel<R, W>(
@@ -126,103 +189,4 @@ pub mod tcp {
         let client_stream = connect_task.await?;
         Ok((server_stream, client_stream))
     }
-}
-
-#[async_std::main]
-pub async fn main() -> anyhow::Result<()> {
-    env_logger::init();
-
-    let port = 9000u16;
-    let n = 5;
-    // let n = 1;
-    let mut tasks = vec![];
-    for n in 0..n {
-        let port = port + n;
-        let task = task::spawn(async move {
-            let _ = channel_extension_async_read_write(port).await;
-        });
-        tasks.push(task);
-    }
-    for task in tasks.iter_mut() {
-        task.await;
-    }
-    Ok(())
-}
-
-async fn channel_extension_async_read_write(port: u16) -> anyhow::Result<()> {
-    // let (mut proto_a, mut proto_b) = create_pair_memory().await?;
-    let (mut proto_a, mut proto_b) = create_pair_tcp(port).await?;
-    let key = [1u8; 32];
-
-    proto_a.open(key).await?;
-    proto_b.open(key).await?;
-
-    let next_a = drive_until_channel(proto_a);
-    let next_b = drive_until_channel(proto_b);
-    let (proto_a, mut channel_a) = next_a.await?;
-    let (proto_b, mut channel_b) = next_b.await?;
-
-    let mut ext_a = channel_a.register_extension("ext");
-    let mut ext_b = channel_b.register_extension("ext");
-
-    drive(proto_a);
-    drive(proto_b);
-    drive(channel_a);
-    drive(channel_b);
-
-    let instant = Instant::now();
-    let limit = 1024 * 1024 * 64;
-    // let limit = 1024 * 64 * 3;
-
-    task::spawn(async move {
-        let mut read_buf = vec![0u8; 1024 * 64];
-        let mut len = 0;
-        loop {
-            let n = ext_b.read(&mut read_buf).await.unwrap();
-            len += n;
-            debug!("B READ: {}", len);
-            ext_b.write_all(&read_buf[..n]).await.unwrap();
-        }
-    });
-
-    let mut len = 0;
-    task::spawn({
-        let mut ext_a = ext_a.clone();
-        let buf = vec![0u8; 1024 * 64];
-        async move {
-            while len < limit + 10 {
-                ext_a.write_all(&buf).await.unwrap();
-                len += buf.len();
-                debug!("A WRITE: {}", len);
-            }
-        }
-    });
-
-    let mut read_buf = vec![0u8; 1024 * 64];
-    let mut len = 0;
-    while len < limit {
-        let n = ext_a.read(&mut read_buf).await.unwrap();
-        len += n;
-        debug!("A READ {}", len);
-    }
-
-    print_stats("done", instant, limit as f64);
-    // eprintln!("total len: {}", len);
-    // eprintln!("total time: {}", len);
-
-    Ok(())
-}
-
-fn print_stats(msg: impl ToString, instant: Instant, bytes: f64) {
-    let msg = msg.to_string();
-    let time = instant.elapsed();
-    let secs = time.as_secs_f64();
-    let bs = bytes / secs;
-    eprintln!(
-        "[{}] time {:?} bytes {} throughput {}/s",
-        msg,
-        time,
-        pretty_bytes(bytes),
-        pretty_bytes(bs)
-    );
 }

--- a/examples/extension.rs
+++ b/examples/extension.rs
@@ -1,0 +1,228 @@
+use async_std::net::TcpStream;
+use async_std::prelude::*;
+use async_std::task::{self, JoinHandle};
+use futures_lite::io::{AsyncRead, AsyncWrite};
+use hypercore_protocol::{Channel, DiscoveryKey, Event, Protocol, ProtocolBuilder};
+use log::*;
+use pretty_bytes::converter::convert as pretty_bytes;
+use std::io;
+use std::time::Instant;
+
+pub type MemoryProtocol = Protocol<sluice::pipe::PipeReader, sluice::pipe::PipeWriter>;
+pub async fn create_pair_memory() -> std::io::Result<(MemoryProtocol, MemoryProtocol)> {
+    let (ar, bw) = sluice::pipe::pipe();
+    let (br, aw) = sluice::pipe::pipe();
+
+    let a = ProtocolBuilder::new(true);
+    let b = ProtocolBuilder::new(false);
+    let a = a.connect_rw(ar, aw);
+    let b = b.connect_rw(br, bw);
+    Ok((a, b))
+}
+
+pub type TcpProtocol = Protocol<TcpStream, TcpStream>;
+pub async fn create_pair_tcp(port: u16) -> std::io::Result<(TcpProtocol, TcpProtocol)> {
+    let (stream_a, stream_b) = tcp::pair(port).await?;
+    let encrypted = true;
+    let a = ProtocolBuilder::new(true)
+        .set_encrypted(encrypted)
+        .connect(stream_a);
+    let b = ProtocolBuilder::new(false)
+        .set_encrypted(encrypted)
+        .connect(stream_b);
+    Ok((a, b))
+}
+
+pub fn next_event<R, W>(
+    mut proto: Protocol<R, W>,
+) -> impl Future<Output = (std::io::Result<Event>, Protocol<R, W>)>
+where
+    R: AsyncRead + Send + Unpin,
+    W: AsyncWrite + Send + Unpin,
+{
+    let task = task::spawn(async move {
+        let e1 = proto.next().await;
+        let e1 = e1.unwrap();
+        (e1, proto)
+    });
+    task
+}
+
+pub fn event_discovery_key(event: Event) -> DiscoveryKey {
+    if let Event::DiscoveryKey(dkey) = event {
+        dkey
+    } else {
+        panic!("Expected discovery key event");
+    }
+}
+
+pub fn event_channel(event: Event) -> Channel {
+    if let Event::Channel(channel) = event {
+        channel
+    } else {
+        panic!("Expected channel event");
+    }
+}
+// Drive a stream to completion in a task.
+fn drive<S>(mut proto: S) -> JoinHandle<()>
+where
+    S: Stream + Send + Unpin + 'static,
+{
+    task::spawn(async move { while let Some(_event) = proto.next().await {} })
+}
+
+// Drive a number of streams to completion.
+// fn drive_all<S>(streams: Vec<S>) -> JoinHandle<()>
+// where
+//     S: Stream + Send + Unpin + 'static,
+// {
+//     let join_handles = streams.into_iter().map(drive);
+//     task::spawn(async move {
+//         for join_handle in join_handles {
+//             join_handle.await;
+//         }
+//     })
+// }
+
+// Drive a protocol stream until the first channel arrives.
+fn drive_until_channel<R, W>(
+    mut proto: Protocol<R, W>,
+) -> JoinHandle<io::Result<(Protocol<R, W>, Channel)>>
+where
+    R: AsyncRead + Send + Unpin + 'static,
+    W: AsyncWrite + Send + Unpin + 'static,
+{
+    task::spawn(async move {
+        while let Some(event) = proto.next().await {
+            let event = event?;
+            match event {
+                Event::Channel(channel) => return Ok((proto, channel)),
+                _ => {}
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "Protocol closed before a channel was opened",
+        ))
+    })
+}
+
+pub mod tcp {
+    use async_std::net::{TcpListener, TcpStream};
+    use async_std::prelude::*;
+    use async_std::task;
+    use std::io::{Error, ErrorKind, Result};
+    pub async fn pair(port: u16) -> Result<(TcpStream, TcpStream)> {
+        let address = format!("localhost:{}", port);
+        let listener = TcpListener::bind(&address).await?;
+        let mut incoming = listener.incoming();
+
+        let connect_task = task::spawn(async move { TcpStream::connect(&address).await });
+
+        let server_stream = incoming.next().await;
+        let server_stream =
+            server_stream.ok_or_else(|| Error::new(ErrorKind::Other, "Stream closed"))?;
+        let server_stream = server_stream?;
+        let client_stream = connect_task.await?;
+        Ok((server_stream, client_stream))
+    }
+}
+
+#[async_std::main]
+pub async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let port = 9000u16;
+    let n = 5;
+    // let n = 1;
+    let mut tasks = vec![];
+    for n in 0..n {
+        let port = port + n;
+        let task = task::spawn(async move {
+            let _ = channel_extension_async_read_write(port).await;
+        });
+        tasks.push(task);
+    }
+    for task in tasks.iter_mut() {
+        task.await;
+    }
+    Ok(())
+}
+
+async fn channel_extension_async_read_write(port: u16) -> anyhow::Result<()> {
+    // let (mut proto_a, mut proto_b) = create_pair_memory().await?;
+    let (mut proto_a, mut proto_b) = create_pair_tcp(port).await?;
+    let key = [1u8; 32];
+
+    proto_a.open(key).await?;
+    proto_b.open(key).await?;
+
+    let next_a = drive_until_channel(proto_a);
+    let next_b = drive_until_channel(proto_b);
+    let (proto_a, mut channel_a) = next_a.await?;
+    let (proto_b, mut channel_b) = next_b.await?;
+
+    let mut ext_a = channel_a.register_extension("ext");
+    let mut ext_b = channel_b.register_extension("ext");
+
+    drive(proto_a);
+    drive(proto_b);
+    drive(channel_a);
+    drive(channel_b);
+
+    let instant = Instant::now();
+    let limit = 1024 * 1024 * 64;
+    // let limit = 1024 * 64 * 3;
+
+    task::spawn(async move {
+        let mut read_buf = vec![0u8; 1024 * 64];
+        let mut len = 0;
+        loop {
+            let n = ext_b.read(&mut read_buf).await.unwrap();
+            len += n;
+            debug!("B READ: {}", len);
+            ext_b.write_all(&read_buf[..n]).await.unwrap();
+        }
+    });
+
+    let mut len = 0;
+    task::spawn({
+        let mut ext_a = ext_a.clone();
+        let buf = vec![0u8; 1024 * 64];
+        async move {
+            while len < limit + 10 {
+                ext_a.write_all(&buf).await.unwrap();
+                len += buf.len();
+                debug!("A WRITE: {}", len);
+            }
+        }
+    });
+
+    let mut read_buf = vec![0u8; 1024 * 64];
+    let mut len = 0;
+    while len < limit {
+        let n = ext_a.read(&mut read_buf).await.unwrap();
+        len += n;
+        debug!("A READ {}", len);
+    }
+
+    print_stats("done", instant, limit as f64);
+    // eprintln!("total len: {}", len);
+    // eprintln!("total time: {}", len);
+
+    Ok(())
+}
+
+fn print_stats(msg: impl ToString, instant: Instant, bytes: f64) {
+    let msg = msg.to_string();
+    let time = instant.elapsed();
+    let secs = time.as_secs_f64();
+    let bs = bytes / secs;
+    eprintln!(
+        "[{}] time {:?} bytes {} throughput {}/s",
+        msg,
+        time,
+        pretty_bytes(bytes),
+        pretty_bytes(bs)
+    );
+}

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -57,8 +57,8 @@ impl Channel {
             .map_err(map_channel_err)
     }
 
-    pub fn register_extension(&mut self, name: impl ToString) -> Extension {
-        self.extensions.register(name.to_string())
+    pub async fn register_extension(&mut self, name: impl ToString) -> Extension {
+        self.extensions.register(name.to_string()).await
     }
 
     pub fn take_receiver(&mut self) -> Option<Receiver<Message>> {

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,9 +1,15 @@
+use crate::constants::MAX_MESSAGE_SIZE;
 use crate::message::{ChannelMessage, ExtensionMessage, Message};
 use crate::schema::*;
 use async_channel::{Receiver, Sender};
-use futures_lite::stream::Stream;
+use futures_lite::{ready, AsyncRead, AsyncWrite, FutureExt, Stream};
 use std::collections::HashMap;
+use std::future::Future;
+use std::io;
 use std::pin::Pin;
+use std::task::{Context, Poll};
+
+const MAX_BODY_SIZE: usize = MAX_MESSAGE_SIZE as usize - 16;
 
 #[derive(Debug)]
 pub struct Extensions {
@@ -47,6 +53,8 @@ impl Extensions {
             local_id,
             outbound_tx: self.outbound_tx.clone(),
             inbound_rx,
+            write_state: WriteState::Idle,
+            read_state: None,
         };
         self.extensions.insert(name, handle);
 
@@ -95,6 +103,52 @@ pub struct Extension {
     local_id: u64,
     outbound_tx: Sender<ChannelMessage>,
     inbound_rx: Receiver<Vec<u8>>,
+    write_state: WriteState,
+    read_state: Option<Vec<u8>>,
+}
+
+type SendFuture = Pin<Box<dyn Future<Output = io::Result<()>> + Send + Sync + 'static>>;
+
+enum WriteState {
+    Sending(SendFuture, usize),
+    Idle,
+}
+
+impl std::fmt::Debug for WriteState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WriteState::Sending(_, len) => {
+                write!(f, "Sending(len={})", len)
+            }
+            WriteState::Idle => write!(f, "Idle"),
+        }
+    }
+}
+
+impl Extension {
+    pub async fn send(&self, message: Vec<u8>) {
+        let message = ExtensionMessage::new(self.local_id, message);
+        let message = ChannelMessage::new(self.channel, Message::Extension(message));
+        self.outbound_tx.send(message).await.unwrap()
+    }
+
+    pub fn send_pinned(&self, message: Vec<u8>) -> SendFuture {
+        let message = ExtensionMessage::new(self.local_id, message);
+        let message = ChannelMessage::new(self.channel, Message::Extension(message));
+        // TODO: It would be nice to do this without cloning, but I didn't find a way so far.
+        let fut = send_message(self.outbound_tx.clone(), message);
+        Box::pin(fut)
+    }
+}
+
+pub async fn send_message(
+    sender: Sender<ChannelMessage>,
+    message: ChannelMessage,
+) -> io::Result<()> {
+    sender
+        .send(message)
+        .await
+        .map_err(|e| io::Error::new(io::ErrorKind::Interrupted, format!("Channel error: {}", e)))
 }
 
 impl Stream for Extension {
@@ -107,10 +161,59 @@ impl Stream for Extension {
     }
 }
 
-impl Extension {
-    pub async fn send(&mut self, message: Vec<u8>) {
-        let message = ExtensionMessage::new(self.local_id, message);
-        let message = ChannelMessage::new(self.channel, Message::Extension(message));
-        self.outbound_tx.send(message).await.unwrap()
+impl AsyncRead for Extension {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut this = self.get_mut();
+        let message = if let Some(message) = this.read_state.take() {
+            message
+        } else {
+            let message = ready!(Pin::new(&mut this).poll_next(cx));
+            message.ok_or_else(|| io::Error::new(io::ErrorKind::Interrupted, "Channel closed"))?
+        };
+        let len = message.len().min(buf.len());
+        buf[..len].copy_from_slice(&message[..len]);
+        if message.len() > len {
+            this.read_state = Some(message[len..].to_vec());
+        } else {
+            this.read_state = None
+        }
+        Poll::Ready(Ok(len))
+    }
+}
+
+impl AsyncWrite for Extension {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        loop {
+            match this.write_state {
+                WriteState::Idle => {
+                    let len = buf.len().min(MAX_BODY_SIZE);
+                    let fut = this.send_pinned(buf.to_vec());
+                    this.write_state = WriteState::Sending(fut, len);
+                }
+                WriteState::Sending(ref mut fut, len) => {
+                    let res = ready!(fut.poll(cx));
+                    let res = res.map(|_| len);
+                    this.write_state = WriteState::Idle;
+                    return Poll::Ready(res);
+                }
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
     }
 }

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -93,6 +93,7 @@ pub struct ExtensionHandle {
 impl ExtensionHandle {
     fn send(&mut self, message: Vec<u8>) {
         self.inbound_tx.try_send(message).unwrap()
+        // let _ = self.inbound_tx.try_send(message);
     }
 }
 
@@ -105,6 +106,20 @@ pub struct Extension {
     inbound_rx: Receiver<Vec<u8>>,
     write_state: WriteState,
     read_state: Option<Vec<u8>>,
+}
+
+impl std::clone::Clone for Extension {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            channel: self.channel,
+            local_id: self.local_id,
+            outbound_tx: self.outbound_tx.clone(),
+            inbound_rx: self.inbound_rx.clone(),
+            write_state: WriteState::Idle,
+            read_state: None,
+        }
+    }
 }
 
 type SendFuture = Pin<Box<dyn Future<Output = io::Result<()>> + Send + Sync + 'static>>;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,0 +1,116 @@
+use crate::message::{ChannelMessage, ExtensionMessage, Message};
+use crate::schema::*;
+use async_channel::{Receiver, Sender};
+use futures_lite::stream::Stream;
+use std::collections::HashMap;
+use std::pin::Pin;
+
+#[derive(Debug)]
+pub struct Extensions {
+    extensions: HashMap<String, ExtensionHandle>,
+    channel: u64,
+    local_ids: Vec<String>,
+    remote_ids: Vec<String>,
+    outbound_tx: Sender<ChannelMessage>,
+}
+
+impl Extensions {
+    pub fn new(outbound_tx: Sender<ChannelMessage>, channel: u64) -> Self {
+        Self {
+            channel,
+            extensions: HashMap::new(),
+            local_ids: vec![],
+            remote_ids: vec![],
+            outbound_tx,
+        }
+    }
+
+    pub fn add_local_name(&mut self, name: String) -> u64 {
+        self.local_ids.push(name.clone());
+        self.local_ids.sort();
+        let local_id = self.local_ids.iter().position(|x| x == &name).unwrap();
+        local_id as u64
+    }
+
+    pub fn register(&mut self, name: String) -> Extension {
+        let local_id = self.add_local_name(name.clone());
+        let (inbound_tx, inbound_rx) = async_channel::unbounded();
+        let handle = ExtensionHandle {
+            name: name.clone(),
+            channel: self.channel,
+            local_id,
+            inbound_tx,
+        };
+        let extension = Extension {
+            name: name.clone(),
+            channel: self.channel,
+            local_id,
+            outbound_tx: self.outbound_tx.clone(),
+            inbound_rx,
+        };
+        self.extensions.insert(name, handle);
+
+        let message = Options {
+            extensions: self.local_ids.clone(),
+            ack: None,
+        };
+        let message = ChannelMessage::new(self.channel, Message::Options(message));
+        self.outbound_tx.try_send(message).unwrap();
+
+        extension
+    }
+
+    pub fn on_remote_update(&mut self, names: Vec<String>) {
+        self.remote_ids = names;
+    }
+
+    pub fn on_message(&mut self, message: ExtensionMessage) {
+        let ExtensionMessage { id, message } = message;
+        if let Some(name) = self.remote_ids.get(id as usize) {
+            if let Some(handle) = self.extensions.get_mut(name) {
+                handle.send(message);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ExtensionHandle {
+    name: String,
+    channel: u64,
+    local_id: u64,
+    inbound_tx: Sender<Vec<u8>>,
+}
+
+impl ExtensionHandle {
+    fn send(&mut self, message: Vec<u8>) {
+        self.inbound_tx.try_send(message).unwrap()
+    }
+}
+
+#[derive(Debug)]
+pub struct Extension {
+    name: String,
+    channel: u64,
+    local_id: u64,
+    outbound_tx: Sender<ChannelMessage>,
+    inbound_rx: Receiver<Vec<u8>>,
+}
+
+impl Stream for Extension {
+    type Item = Vec<u8>;
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inbound_rx).poll_next(cx)
+    }
+}
+
+impl Extension {
+    pub async fn send(&mut self, message: Vec<u8>) {
+        let message = ExtensionMessage::new(self.local_id, message);
+        let message = ChannelMessage::new(self.channel, Message::Extension(message));
+        self.outbound_tx.send(message).await.unwrap()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 mod builder;
 mod channels;
 mod constants;
+mod extension;
 mod message;
 mod noise;
 mod protocol;
@@ -73,6 +74,7 @@ pub mod schema {
 
 pub use builder::{Builder as ProtocolBuilder, Options};
 pub use channels::Channel;
+pub use extension::Extension;
 pub use message::Message;
 pub use protocol::{DiscoveryKey, Event, Key, Protocol};
 pub use util::discovery_key;

--- a/src/message.rs
+++ b/src/message.rs
@@ -333,7 +333,7 @@ pub struct ExtensionMessage {
     pub message: Vec<u8>,
 }
 impl ExtensionMessage {
-    fn _new(id: u64, message: Vec<u8>) -> Self {
+    pub fn new(id: u64, message: Vec<u8>) -> Self {
         Self { id, message }
     }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -12,7 +12,7 @@ use _util::*;
 
 #[async_std::test]
 async fn basic_protocol() -> anyhow::Result<()> {
-    env_logger::init();
+    // env_logger::init();
     let (proto_a, proto_b) = create_pair_memory().await?;
 
     let next_a = next_event(proto_a);
@@ -102,6 +102,7 @@ async fn basic_protocol() -> anyhow::Result<()> {
 
     assert!(matches!(event_a, Ok(Event::Close(_))));
     assert!(matches!(event_b, Ok(Event::Close(_))));
+    eprintln!("TEST GOOD");
 
     return Ok(());
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -102,7 +102,5 @@ async fn basic_protocol() -> anyhow::Result<()> {
 
     assert!(matches!(event_a, Ok(Event::Close(_))));
     assert!(matches!(event_b, Ok(Event::Close(_))));
-    eprintln!("TEST GOOD");
-
     return Ok(());
 }

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -4,6 +4,7 @@ use async_std::net::TcpStream;
 use async_std::prelude::*;
 use async_std::task::{self, JoinHandle};
 use futures_lite::io::{AsyncRead, AsyncWrite};
+// use futures_lite::{AsyncReadExt, AsyncWriteExt};
 use hypercore_protocol::schema::*;
 use hypercore_protocol::{discovery_key, Channel, Event, Message, Protocol, ProtocolBuilder};
 use std::io;
@@ -18,6 +19,19 @@ where
 {
     task::spawn(async move { while let Some(_event) = proto.next().await {} })
 }
+
+// Drive a number of streams to completion.
+// fn drive_all<S>(streams: Vec<S>) -> JoinHandle<()>
+// where
+//     S: Stream + Send + Unpin + 'static,
+// {
+//     let join_handles = streams.into_iter().map(drive);
+//     task::spawn(async move {
+//         for join_handle in join_handles {
+//             join_handle.await;
+//         }
+//     })
+// }
 
 // Drive a protocol stream until the first channel arrives.
 fn drive_until_channel<R, W>(
@@ -102,5 +116,61 @@ async fn channel_extension() -> anyhow::Result<()> {
     let response = ext_a.next().await;
     assert_eq!(response, Some(b"ack".to_vec()));
     // eprintln!("A received: {:?}", response.map(String::from_utf8));
+    Ok(())
+}
+
+#[async_std::test]
+async fn channel_extension_async_read_write() -> anyhow::Result<()> {
+    // env_logger::init();
+    let (mut proto_a, mut proto_b) = create_pair_memory().await?;
+    let key = [1u8; 32];
+
+    proto_a.open(key).await?;
+    proto_b.open(key).await?;
+
+    let next_a = drive_until_channel(proto_a);
+    let next_b = drive_until_channel(proto_b);
+    let (proto_a, mut channel_a) = next_a.await?;
+    let (proto_b, mut channel_b) = next_b.await?;
+
+    let mut ext_a = channel_a.register_extension("ext");
+    let mut ext_b = channel_b.register_extension("ext");
+
+    drive(proto_a);
+    drive(proto_b);
+    drive(channel_a);
+    drive(channel_b);
+
+    task::spawn(async move {
+        let mut read_buf = vec![0u8; 3];
+        // let mut total = 0;
+        let mut res = vec![];
+        while res.len() < 10 {
+            let n = ext_b.read(&mut read_buf).await.unwrap();
+            // eprintln!(
+            //     "B read: n {} buf {}",
+            //     n,
+            //     std::str::from_utf8(&read_buf[..n]).unwrap()
+            // );
+            res.extend_from_slice(&read_buf[..n]);
+        }
+        assert_eq!(res, b"helloworld".to_vec());
+
+        let write = b"ack".to_vec();
+        ext_b.write_all(&write).await.unwrap();
+    });
+
+    ext_a.write_all(b"hello").await.unwrap();
+    ext_a.write_all(b"world").await.unwrap();
+
+    let mut read_buf = vec![0u8; 5];
+    let n = ext_a.read(&mut read_buf).await.unwrap();
+    assert_eq!(n, 3);
+    assert_eq!(&read_buf[..n], b"ack");
+    // eprintln!(
+    //     "A read: n {} buf {}",
+    //     n,
+    //     std::str::from_utf8(&read_buf[..n]).unwrap()
+    // );
     Ok(())
 }

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -61,8 +61,8 @@ async fn stream_extension() -> anyhow::Result<()> {
     // env_logger::init();
     let (mut proto_a, mut proto_b) = create_pair_memory().await?;
 
-    let mut ext_a = proto_a.register_extension("ext");
-    let mut ext_b = proto_b.register_extension("ext");
+    let mut ext_a = proto_a.register_extension("ext").await;
+    let mut ext_b = proto_b.register_extension("ext").await;
 
     drive(proto_a);
     drive(proto_b);
@@ -96,8 +96,8 @@ async fn channel_extension() -> anyhow::Result<()> {
     let (proto_a, mut channel_a) = next_a.await?;
     let (proto_b, mut channel_b) = next_b.await?;
 
-    let mut ext_a = channel_a.register_extension("ext");
-    let mut ext_b = channel_b.register_extension("ext");
+    let mut ext_a = channel_a.register_extension("ext").await;
+    let mut ext_b = channel_b.register_extension("ext").await;
 
     drive(proto_a);
     drive(proto_b);
@@ -133,8 +133,8 @@ async fn channel_extension_async_read_write() -> anyhow::Result<()> {
     let (proto_a, mut channel_a) = next_a.await?;
     let (proto_b, mut channel_b) = next_b.await?;
 
-    let mut ext_a = channel_a.register_extension("ext");
-    let mut ext_b = channel_b.register_extension("ext");
+    let mut ext_a = channel_a.register_extension("ext").await;
+    let mut ext_b = channel_b.register_extension("ext").await;
 
     drive(proto_a);
     drive(proto_b);

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -1,0 +1,106 @@
+#![allow(dead_code, unused_imports)]
+
+use async_std::net::TcpStream;
+use async_std::prelude::*;
+use async_std::task::{self, JoinHandle};
+use futures_lite::io::{AsyncRead, AsyncWrite};
+use hypercore_protocol::schema::*;
+use hypercore_protocol::{discovery_key, Channel, Event, Message, Protocol, ProtocolBuilder};
+use std::io;
+
+mod _util;
+use _util::*;
+
+// Drive a stream to completion in a task.
+fn drive<S>(mut proto: S) -> JoinHandle<()>
+where
+    S: Stream + Send + Unpin + 'static,
+{
+    task::spawn(async move { while let Some(_event) = proto.next().await {} })
+}
+
+// Drive a protocol stream until the first channel arrives.
+fn drive_until_channel<R, W>(
+    mut proto: Protocol<R, W>,
+) -> JoinHandle<io::Result<(Protocol<R, W>, Channel)>>
+where
+    R: AsyncRead + Send + Unpin + 'static,
+    W: AsyncWrite + Send + Unpin + 'static,
+{
+    task::spawn(async move {
+        while let Some(event) = proto.next().await {
+            let event = event?;
+            match event {
+                Event::Channel(channel) => return Ok((proto, channel)),
+                _ => {}
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "Protocol closed before a channel was opened",
+        ))
+    })
+}
+
+#[async_std::test]
+async fn stream_extension() -> anyhow::Result<()> {
+    // env_logger::init();
+    let (mut proto_a, mut proto_b) = create_pair_memory().await?;
+
+    let mut ext_a = proto_a.register_extension("ext");
+    let mut ext_b = proto_b.register_extension("ext");
+
+    drive(proto_a);
+    drive(proto_b);
+
+    task::spawn(async move {
+        while let Some(message) = ext_b.next().await {
+            assert_eq!(message, b"hello".to_vec());
+            // eprintln!("B received: {:?}", String::from_utf8(message));
+            ext_b.send(b"ack".to_vec()).await;
+        }
+    });
+
+    ext_a.send(b"hello".to_vec()).await;
+    let response = ext_a.next().await;
+    assert_eq!(response, Some(b"ack".to_vec()));
+    // eprintln!("A received: {:?}", response.map(String::from_utf8));
+    Ok(())
+}
+
+#[async_std::test]
+async fn channel_extension() -> anyhow::Result<()> {
+    // env_logger::init();
+    let (mut proto_a, mut proto_b) = create_pair_memory().await?;
+    let key = [1u8; 32];
+
+    proto_a.open(key).await?;
+    proto_b.open(key).await?;
+
+    let next_a = drive_until_channel(proto_a);
+    let next_b = drive_until_channel(proto_b);
+    let (proto_a, mut channel_a) = next_a.await?;
+    let (proto_b, mut channel_b) = next_b.await?;
+
+    let mut ext_a = channel_a.register_extension("ext");
+    let mut ext_b = channel_b.register_extension("ext");
+
+    drive(proto_a);
+    drive(proto_b);
+    drive(channel_a);
+    drive(channel_b);
+
+    task::spawn(async move {
+        while let Some(message) = ext_b.next().await {
+            // eprintln!("B received: {:?}", String::from_utf8(message));
+            assert_eq!(message, b"hello".to_vec());
+            ext_b.send(b"ack".to_vec()).await;
+        }
+    });
+
+    ext_a.send(b"hello".to_vec()).await;
+    let response = ext_a.next().await;
+    assert_eq!(response, Some(b"ack".to_vec()));
+    // eprintln!("A received: {:?}", response.map(String::from_utf8));
+    Ok(())
+}


### PR DESCRIPTION
This PR adds support for protocol extension.

It should have full support for everything from the NodeJS version.

- Extensions can be registered either on the outer stream or on a channel.
- Extensions are identified by a string. Upon registering an extension, a `Options` message is sent with the extension names. Each extension message is then identified by the ID from the last `Options` message.
- Extension messages for "unknown" extensions are dropped (without raising an error).

This all works.

Additionally, Extensions implement `AsyncRead` and `AsyncWrite` traits! This should make it straightforward to use extensions for other protocols. AsyncRead and AsyncWrite are the most used abstraction for protocols I think.

See `examples/extension.rs` for an example on how to use this.

Also, together with #8 and #9 (on which this PR depends) this is all now fast and smooth. I'm getting higher throughput per second than the NodeJS version finally :slightly_smiling_face: 