### PR TITLE
Make Protocol generic over a single IO struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this Rust implementation of hypercore-protocol will be do
 
 ### unreleased
 
+* Breaking: Changed the generic argument of the Protocol struct to be a single IO handle (AsyncRead + AsyncWrite) in place of a R: AsyncRead and W: AsyncWrite. This is a change in the public API. If you have seperate reader and writer structs, a Duplex handle is provided that combines the reader and writer. If you have a struct that is both AsyncRead and AsyncWrite, the Protocol is now generic just over that struct.
 * Changed key and discovery key values to be `[u8; 32]` in place of `Vec<u8>`. To convert from a `Vec<u8>`, use `key.try_into().unwrap()` if you're sure that the key is a 32 byte long `u8` vector.
 * Reworked internals to use manual poll functions and not an async function. The `Protocol` struct now directly implements `Stream`.
 

--- a/examples/extension.rs
+++ b/examples/extension.rs
@@ -124,7 +124,7 @@ fn print_stats(msg: impl ToString, instant: Instant, bytes: f64) {
     );
 }
 
-pub type TcpProtocol = Protocol<TcpStream, TcpStream>;
+pub type TcpProtocol = Protocol<TcpStream>;
 pub async fn create_pair_tcp(
     port: u16,
     encrypted: bool,
@@ -148,12 +148,11 @@ where
 }
 
 // Drive a protocol stream until the first channel arrives.
-fn drive_until_channel<R, W>(
-    mut proto: Protocol<R, W>,
-) -> JoinHandle<io::Result<(Protocol<R, W>, Channel)>>
+fn drive_until_channel<IO>(
+    mut proto: Protocol<IO>,
+) -> JoinHandle<io::Result<(Protocol<IO>, Channel)>>
 where
-    R: AsyncRead + Send + Unpin + 'static,
-    W: AsyncWrite + Send + Unpin + 'static,
+    IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     task::spawn(async move {
         while let Some(event) = proto.next().await {

--- a/examples/pipe.rs
+++ b/examples/pipe.rs
@@ -78,10 +78,9 @@ async fn run_echo(config: Config, i: u64) -> Result<()> {
 
 // The onconnection handler is called for each incoming connection (if server)
 // or once when connected (if client).
-async fn onconnection<R, W>(config: Config, i: u64, mut protocol: Protocol<R, W>) -> Result<u64>
+async fn onconnection<IO>(config: Config, i: u64, mut protocol: Protocol<IO>) -> Result<u64>
 where
-    R: AsyncRead + Send + Unpin + 'static,
-    W: AsyncWrite + Send + Unpin + 'static,
+    IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     let key = [0u8; 32];
     let is_initiator = protocol.is_initiator();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,4 @@
+use crate::duplex::Duplex;
 use crate::Protocol;
 use futures_lite::io::{AsyncRead, AsyncWrite};
 
@@ -51,19 +52,20 @@ impl Builder {
     }
 
     /// Create the protocol from a stream that implements AsyncRead + AsyncWrite + Clone.
-    pub fn connect<S>(self, stream: S) -> Protocol<S, S>
+    pub fn connect<IO>(self, io: IO) -> Protocol<IO>
     where
-        S: AsyncRead + AsyncWrite + Send + Unpin + Clone + 'static,
+        IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
     {
-        Protocol::new(stream.clone(), stream, self.0)
+        Protocol::new(io, self.0)
     }
 
     /// Create the protocol from an AsyncRead reader and AsyncWrite writer.
-    pub fn connect_rw<R, W>(self, reader: R, writer: W) -> Protocol<R, W>
+    pub fn connect_rw<R, W>(self, reader: R, writer: W) -> Protocol<Duplex<R, W>>
     where
         R: AsyncRead + Send + Unpin + 'static,
         W: AsyncWrite + Send + Unpin + 'static,
     {
-        Protocol::new(reader, writer, self.0)
+        let io = Duplex::new(reader, writer);
+        Protocol::new(io, self.0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
 mod builder;
 mod channels;
 mod constants;
+mod duplex;
 mod extension;
 mod message;
 mod noise;
@@ -77,6 +78,7 @@ pub mod schema {
 
 pub use builder::{Builder as ProtocolBuilder, Options};
 pub use channels::Channel;
+pub use duplex::Duplex;
 pub use extension::Extension;
 pub use message::Message;
 pub use protocol::{DiscoveryKey, Event, Key, Protocol};

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -34,12 +34,11 @@ where
 // }
 
 // Drive a protocol stream until the first channel arrives.
-fn drive_until_channel<R, W>(
-    mut proto: Protocol<R, W>,
-) -> JoinHandle<io::Result<(Protocol<R, W>, Channel)>>
+fn drive_until_channel<IO>(
+    mut proto: Protocol<IO>,
+) -> JoinHandle<io::Result<(Protocol<IO>, Channel)>>
 where
-    R: AsyncRead + Send + Unpin + 'static,
-    W: AsyncWrite + Send + Unpin + 'static,
+    IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     task::spawn(async move {
         while let Some(event) = proto.next().await {


### PR DESCRIPTION
Breaking: Changed the generic argument of the Protocol struct to be a single IO handle (AsyncRead + AsyncWrite) in place of a R: AsyncRead and W: AsyncWrite. This is a change in the public API. If you have seperate reader and writer structs, a Duplex handle is provided that combines the reader and writer. If you have a struct that is both AsyncRead and AsyncWrite, the Protocol is now generic just over that struct.